### PR TITLE
JB-1203 Fix npm dependency because of scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "npm": ">= 1.1.x"
   },
-  "dependencies": {
+  "devDependencies": {
     "grunt": "0.4.5",
     "grunt-contrib-watch": "0.6.1",
     "grunt-shell": "1.1.2",


### PR DESCRIPTION
Ticket: [JB-1203](https://juiceanalytics.atlassian.net/browse/JB-1203)
Type: Fix

#### This PR introduces the following changes

- gruntfile was scoped to devDependencies and failed because the grunt dependencies were in the dependencies block.