### PR TITLE
OPS-864: Adds HSTM loginproxy container

### DIFF
--- a/environments/hstm-core/docker-compose.yml
+++ b/environments/hstm-core/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     links:
       - postgres
       - redis
+      - loginproxy
     environment:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
@@ -44,3 +45,7 @@ services:
     image: "postgres:9.3-alpine"
   redis:
     image: "redis:2.8.6"
+  loginproxy:
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/hstm-loginproxy-devlandia:1.0"
+    ports:
+      - "8889:8889"


### PR DESCRIPTION
Signed-off-by: Jason Myers <jason@jasonamyers.com>

Ticket: [OPS-864](https://juiceanalytics.atlassian.net/browse/OPS-864)
Type: Fix/Improvement/Feature

#### This PR introduces the following changes

- Adds HSTM loginproxy container on port 8889
- Links with HSTM Juicebox Container
