### PR TITLE
Update to point at venv/bin/python since it changed after building fr…

### DIFF
--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:stable"
-    command: bash -c "python docker/entrypoint.py"
+    command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"
       - "8888:8888"


### PR DESCRIPTION
Ticket: [OPS-830](https://juiceanalytics.atlassian.net/browse/OPS-830)
Type: Fix

#### This PR introduces the following changes

- As part of fixing up conflicts in the JB-1174 branch of Juicebox, I'm now building from the shared base Juicebox docker container, and a venv is used there, so I have to point the interpreter used by the entrypoint script at the new venv.  This will only effect stable environment for now.