### PR TITLE
Update dev environment entrypoint since we'll start getting regular u…

### DIFF
--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:dev"
-    command: bash -c "python docker/entrypoint.py"
+    command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"
       - "8888:8888"


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- Updates dev environment docker-compose file entrypoint to point at the new virtualenv.  Useful now since we'll be getting regular dev container updates through CI/CD.