### PR TITLE
OPS-1041: Adding AWS_DEFAULT_REGION to all docker-compose files

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:

--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:

--- a/environments/hstm-core/docker-compose.yml
+++ b/environments/hstm-core/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_PROFILE=hstm
   postgres:

--- a/environments/hstm-dev/docker-compose.yml
+++ b/environments/hstm-dev/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:

--- a/environments/hstm-stable/docker-compose.yml
+++ b/environments/hstm-stable/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:

--- a/environments/hstm-test/docker-compose.yml
+++ b/environments/hstm-test/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_PROFILE=hstm
   postgres:

--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ENVIRONMENT=docker
       - DJANGO_SETTINGS_MODULE=fruition.settings.docker
       - REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
   postgres:
     environment:


### PR DESCRIPTION
Signed-off-by: Jason Myers <jason@jasonamyers.com>

Ticket: [OPS-1041](https://juiceanalytics.atlassian.net/browseOPS-1041)
Type: Fix/Improvement/Feature

#### This PR introduces the following changes

- Adds AWS_DEFAULT_REGION