### PR TITLE
Adding generator-juicebox to enable yo juicebox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 .idea
 !.idea/runConfigurations/*
+
+# yo juicebox ignore
+.yo-rc.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juiceinc/devlandia.git"
+  },
+  "dependencies": {
+    "generator-juicebox": "git@github.com:juiceinc/generator-juicebox.git#master"
+  },
+  "engines": {
+    "npm": ">= 5.4"
+  }
+}


### PR DESCRIPTION
Ticket: [JB-XXXX](https://juiceanalytics.atlassian.net/browse/JB-XXXX)
Type: Feature

#### This PR introduces the following changes

- Replacing `jb create` with `yo juicebox`. Most of the work in is jbcli, this sets things up on the devlandia side.

## Documentation

This PR adds a npm package.json. The rest of yo installation is bootstrapped by jbcli. jb cli 0.9.0 adds a yo_upgrade command that performs the npm install and sets up a .yo-rc.json file.

## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
