### PR TITLE
pass through the AWS environment variables to the juicebox container

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/hstm-core/docker-compose.yml
+++ b/environments/hstm-core/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_PROFILE=hstm
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/hstm-dev/docker-compose.yml
+++ b/environments/hstm-dev/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/hstm-stable/docker-compose.yml
+++ b/environments/hstm-stable/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/hstm-test/docker-compose.yml
+++ b/environments/hstm-test/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_PROFILE=hstm
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   postgres:
     environment:
       - POSTGRES_USER=juicebox


### PR DESCRIPTION
Type: Improvement

#### This PR introduces the following changes

This allows running juicebox without `~/.boto`, if you set the `AWS_*` environment variables before running `jb start` (for example, by using the `portray` tool). I did this in all the docker-compose.yml files.

I also made sure that docker doesn't blow up when these envvars *aren't* defined, so you can keep using `~/.boto` without `portray`.

## Documentation

```
$ portray auth
...
$ jb start
```