### PR TITLE
map ~/.config/juicebox to /root/.config/juicebox in all docker-compose configs

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./fruition:/code
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/hstm-core/docker-compose.yml
+++ b/environments/hstm-core/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./hstm-juicebox:/code
       - ../../apps:/code/apps
       - ~/.aws:/root/.aws:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/hstm-dev/docker-compose.yml
+++ b/environments/hstm-dev/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/hstm-stable/docker-compose.yml
+++ b/environments/hstm-stable/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/hstm-test/docker-compose.yml
+++ b/environments/hstm-test/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.aws:/root/.aws:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ../../apps:/code/apps
       - ~/.boto:/root/.boto:ro
+      - ~/.config/juicebox:/root/.config/juicebox:ro
     links:
       - postgres
       - redis


### PR DESCRIPTION
Ticket: [JB-1632](https://juiceanalytics.atlassian.net/browse/JB-1632)
Type: Feature

#### This PR introduces the following changes

Map the ~/.config/juicebox directory into the containers, to allow using local-secrets in juicebox in devlandia.
