### PR TITLE
use npm's simplified syntax for depending on github dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/juiceinc/devlandia.git"
   },
   "dependencies": {
-    "generator-juicebox": "git@github.com:juiceinc/generator-juicebox.git#master"
+    "generator-juicebox": "juiceinc/generator-juicebox.git"
   },
   "engines": {
     "npm": ">= 5.4"


### PR DESCRIPTION
Type: Improvement

#### This PR introduces the following changes

Change the package.json dependency on `git@github.com:juiceinc/generator-juicebox.git#master` to `juiceinc/generator-juicebox.git`

This is more friendly since it allows different transports (e.g. HTTPS instead of SSH, which windows developers often use).

