### PR TITLE
Update all HSTM environments to point at working container tag

### DIFF
--- a/environments/hstm-dev/docker-compose.yml
+++ b/environments/hstm-dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
     command: bash -c "python docker/entrypoint.py"
     ports:
       - "8000:8000"

--- a/environments/hstm-stable/docker-compose.yml
+++ b/environments/hstm-stable/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:stable"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- Updates the docker-compose file in the remaining HSTM environments so that the container tag points at the current tag since we only have 1 active branch for CI/CD at the moment.