### PR TITLE
[OPS-819] install dependencies from requirements.txt when starting up the core environment

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:dev"
-    command: bash -c "/venv/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -q -r requirements.txt && /venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"
       - "8888:8888"


### PR DESCRIPTION
Ticket: [OPS-819](https://juiceanalytics.atlassian.net/browse/OPS-819)
Type: Improvement

#### This PR introduces the following changes

Adds a `/venv/bin/pip install -r requirements.txt` to the `command` to run when starting up juicebox in the `core` environment.

This only effects `core` because it's the only environment where the juicebox code being run (your local fruition checkout) doesn't necessarily match the dependencies that are installed in the image.

