### PR TITLE
fixes to the setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,8 +11,7 @@ set -x
 pip install virtualenv virtualenvwrapper
 
 grep "WORKON_HOME" ~/.bash_profile || echo "WORKON_HOME="~/.virtualenvs"" >> ~/.bash_profile
-if [ -f /usr/local/bin/setup.sh ]
-   grep "/usr/local/bin/setup.sh" ~/.bash_profile || echo "source /usr/local/bin/setup.sh" >> ~/.bash_profile
+grep "/usr/local/bin/virtualenvwrapper.sh" ~/.bash_profile || echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bash_profile
 source $HOME/.bash_profile
 chmod 400 insecure_key && cp insecure_key ~/.ssh/
 mkvirtualenv devlandia -p python2.7

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,17 +6,40 @@ if [ ! -e insecure_key ]; then
     exit 1
 fi
 
-set -x
-
+echo "installing virtualenv and virtualenvwrapper..."
 pip install virtualenv virtualenvwrapper
 
+echo "modifying ~/.bash_profile if needed..."
 grep "WORKON_HOME" ~/.bash_profile || echo "WORKON_HOME="~/.virtualenvs"" >> ~/.bash_profile
 grep "/usr/local/bin/virtualenvwrapper.sh" ~/.bash_profile || echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bash_profile
+
+echo "sourcing ~/.bash_profile..."
 source $HOME/.bash_profile
-chmod 400 insecure_key && cp insecure_key ~/.ssh/
+
+echo "copying insecure ssh key into place if needed..."
+if [ ! -e ~/.ssh/insecure_key ]; then
+    chmod 400 insecure_key
+    cp insecure_key ~/.ssh/
+fi
+
+echo "creating virtualenv \"devlandia\"..."
 mkvirtualenv devlandia -p python2.7
 echo "cd $PWD" >> ~/.virtualenvs/devlandia/bin/postactivate
+
+echo "activating virtualenv \"devlandia\""
 source $HOME/.virtualenvs/devlandia/bin/activate
+
+echo "installing requirements into \"devlandia\"..."
 pip install -r requirements.txt
-sudo mkdir /code
-sudo touch /code/manage.py
+
+echo "creating /code/manage.py if needed..."
+if [ ! -e /code/manage.py ]; then
+   sudo mkdir /code
+   sudo touch /code/manage.py
+fi
+
+echo "Setup complete. If you saw no catastrophic errors above,"
+echo "then you should be able to **open a new terminal** and run"
+echo
+echo "    workon devlandia"
+echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 
+if [ ! -e insecure_key ]; then
+    echo "Could not find ./insecure_key."
+    echo "Please run this script from the base of devlandia."
+    exit 1
+fi
+
+set -x
+
 pip install virtualenv virtualenvwrapper
-echo "WORKON_HOME="~/.virtualenvs"" >> ~/.bash_profile
-echo "source /usr/local/bin/setup.sh" >> ~/.bash_profile
+
+grep "WORKON_HOME" ~/.bash_profile || echo "WORKON_HOME="~/.virtualenvs"" >> ~/.bash_profile
+if [ -f /usr/local/bin/setup.sh ]
+   grep "/usr/local/bin/setup.sh" ~/.bash_profile || echo "source /usr/local/bin/setup.sh" >> ~/.bash_profile
 source $HOME/.bash_profile
 chmod 400 insecure_key && cp insecure_key ~/.ssh/
-mkvirtualenv devlandia -p /usr/local/Cellar/python/2.7.14/bin/python
+mkvirtualenv devlandia -p python2.7
 echo "cd $PWD" >> ~/.virtualenvs/devlandia/bin/postactivate
 source $HOME/.virtualenvs/devlandia/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
Ticket: Pop-up
Type: Fix

#### This PR introduces the following changes

- don't run if not running from the correct directory
- if re-run, don't toss multiple lines into bash_profile
- if /usr/local/bin/setup.sh doesn't exist, don't try to run it
- homebrew won't be on 2.7.14 forever, just assume homebrew is installed correctly and use 2.7 from the path

James was having trouble with the devlandia setup script on his new OSX install. (It broke in a few different ways.) I just created this to hold some quick changes to get him running. We should see about doing something more robust in the future.