### PR TITLE
Fix/re add run configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ ENV/
 # Rope project settings
 .ropeproject
 
-.idea
+.idea/*
 !.idea/runConfigurations/
 
 # yo juicebox ignore

--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ ENV/
 .ropeproject
 
 .idea
-!.idea/runConfigurations/*
+!.idea/runConfigurations/
 
 # yo juicebox ignore
 .yo-rc.json

--- a/.idea/runConfigurations/HSTM_Juicebox.xml
+++ b/.idea/runConfigurations/HSTM_Juicebox.xml
@@ -1,0 +1,50 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HSTM-Juicebox" type="Python.DjangoServer" factoryName="Django server" activateToolWindowBeforeRun="false">
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="fruition.settings.docker" />
+      <env name="APP_ID" value="1ec756a5-e04a-4885-87ad-3325bbdd4872" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="ENVIRONMENT" value="docker" />
+      <env name="AWS_DEFAULT_REGION" value="us-east-1" />
+      <env name="REGION" value="us-east-1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/apps" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <module name="devlandia" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="version" value="1" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="host" value="" />
+    <option name="additionalOptions" value="runserver 0.0.0.0:8888 --settings=fruition.settings.docker" />
+    <option name="browserUrl" value="http://localhost:8888/admin" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="true" />
+    <option name="customRunCommand" value="/code/manage.py" />
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/HSTM_Juicebox_Debug_Fix.xml
+++ b/.idea/runConfigurations/HSTM_Juicebox_Debug_Fix.xml
@@ -1,0 +1,50 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HSTM-Juicebox Debug Fix" type="Python.DjangoServer" factoryName="Django server" activateToolWindowBeforeRun="false">
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="fruition.settings.docker" />
+      <env name="APP_ID" value="1ec756a5-e04a-4885-87ad-3325bbdd4872" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="ENVIRONMENT" value="docker" />
+      <env name="AWS_DEFAULT_REGION" value="us-east-1" />
+      <env name="REGION" value="us-east-1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <module name="devlandia" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="version" value="1" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="host" value="" />
+    <option name="additionalOptions" value="0.0.0.0:8888 --settings=fruition.settings.docker" />
+    <option name="browserUrl" value="http://localhost:8888/admin" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="false" />
+    <option name="customRunCommand" value="/code/manage.py" />
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Juicebox.xml
+++ b/.idea/runConfigurations/Juicebox.xml
@@ -1,0 +1,57 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Juicebox" type="Python.DjangoServer" factoryName="Django server">
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="fruition.settings.docker" />
+      <env name="APP_ID" value="1ec756a5-e04a-4885-87ad-3325bbdd4872" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="ENVIRONMENT" value="docker" />
+      <env name="AWS_DEFAULT_REGION" value="us-east-1" />
+      <env name="REGION" value="us-east-1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <module name="devlandia" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="version" value="1" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <PathMappingSettings>
+      <option name="pathMappings">
+        <list>
+          <mapping local-root="$PROJECT_DIR$/apps" remote-root="/code/apps" />
+        </list>
+      </option>
+    </PathMappingSettings>
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="host" value="" />
+    <option name="additionalOptions" value="runserver 0.0.0.0:8888 --settings=fruition.settings.docker" />
+    <option name="browserUrl" value="http://localhost:8888/" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="true" />
+    <option name="customRunCommand" value="/code/manage.py" />
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Juicebox_Debug_Fix.xml
+++ b/.idea/runConfigurations/Juicebox_Debug_Fix.xml
@@ -1,0 +1,57 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Juicebox Debug Fix" type="Python.DjangoServer" factoryName="Django server">
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="fruition.settings.docker" />
+      <env name="APP_ID" value="1ec756a5-e04a-4885-87ad-3325bbdd4872" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="ENVIRONMENT" value="docker" />
+      <env name="AWS_DEFAULT_REGION" value="us-east-1" />
+      <env name="REGION" value="us-east-1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <module name="devlandia" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="version" value="1" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <PathMappingSettings>
+      <option name="pathMappings">
+        <list>
+          <mapping local-root="$PROJECT_DIR$/apps" remote-root="/code/apps" />
+        </list>
+      </option>
+    </PathMappingSettings>
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="host" value="" />
+    <option name="additionalOptions" value="0.0.0.0:8888 --settings=fruition.settings.docker" />
+    <option name="browserUrl" value="http://localhost:8888/" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="false" />
+    <option name="customRunCommand" value="/code/manage.py" />
+    <method />
+  </configuration>
+</component>


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- When we opened up this repo we inadvertently lost the runConfiguration files due to the gitignore similarly to the apps/__init__.py issue we had.  Adding them back and fixing gitignore pattern for unignoring them (was wanting me to force add them back to git before removing the trailing /* on the unexclusion line.)