### PR TITLE
make hstm environments use containers built from their develop branch.

### DIFF
--- a/environments/hstm-core/docker-compose.yml
+++ b/environments/hstm-core/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:develop"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"

--- a/environments/hstm-dev/docker-compose.yml
+++ b/environments/hstm-dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:develop"
     command: bash -c "python docker/entrypoint.py"
     ports:
       - "8000:8000"

--- a/environments/hstm-stable/docker-compose.yml
+++ b/environments/hstm-stable/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:develop"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"

--- a/environments/hstm-test/docker-compose.yml
+++ b/environments/hstm-test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:dev-JB-1196_dockerize"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/controlcenter-dev:develop"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "8000:8000"


### PR DESCRIPTION
Ticket: pop-up
Type: Improvement

#### This PR introduces the following changes

- Makes the healthstream devlandia environments pull an image tagged "develop"

## Documentation

Healthstream devlandia environments are currently set to always use docker images tagged `JB-1196/dockerize`.
This means @musicionary has to merge every update to release branches into that weird old feature branch to make local development environments pick them up!
I thought I had fixed this with my work on [JB-1196](https://juiceanalytics.atlassian.net/browse/JB-1196) but I was mistaken.
Per my advice, @musicionary has updated the `develop` branch in `hstm-juicebox` to point to the same commit as the latest stable release tag. `develop` here means, "this should go to devlandia environments." Unfortunately, I realized too late that this is insufficient; when the branch is `develop`, Jenkins builds docker containers and tags them with the output of `git describe`. There is no common/latest `develop` tag as I was expecting.

So, before this change can be merged, some changes to Jenkinsfiles (or the Makefile or scripts/*version.sh) needs to occur so Jenkins pushes a docker container tagged `develop` to the `controlcenter-dev` container repository. (Or, you could delete the `develop` branch from `hstm-juicebox` and use a branch name like `stable`, which might be preferable and more accurate, if that's enough to make things work. Check in `scripts/version.sh`)

But I'm not going to have time to do that before I leave without introducing more divergence between `hstm-juicebox` and `fruition` repos, and we don't want that.

See [slack conversation](https://juiceanalytics.slack.com/archives/C02FARWD7/p1532714525000377)