### PR TITLE
pass docker-compose-*.yml as files to all docker-compose commands

### DIFF
--- a/jbcli/jbcli/tests/test_docker.py
+++ b/jbcli/jbcli/tests/test_docker.py
@@ -10,21 +10,21 @@ class TestDocker:
     def test_up(self, check_mock):
         dockerutil.up()
         assert check_mock.mock_calls == [
-            call(['docker-compose', 'up'])
+            call(['docker-compose', '-f', 'docker-compose.yml', 'up'])
         ]
 
     @patch('jbcli.utils.dockerutil.check_call')
     def test_destroy(self, check_mock):
         dockerutil.destroy()
         assert check_mock.mock_calls == [
-            call(['docker-compose', 'down'])
+            call(['docker-compose', '-f', 'docker-compose.yml', 'down'])
         ]
 
     @patch('jbcli.utils.dockerutil.check_call')
     def test_halt(self, check_mock):
         dockerutil.halt()
         assert check_mock.mock_calls == [
-            call(['docker-compose', 'stop'])
+            call(['docker-compose', '-f', 'docker-compose.yml', 'stop'])
         ]
 
     @patch('jbcli.utils.dockerutil.client')

--- a/jbcli/jbcli/tests/test_docker.py
+++ b/jbcli/jbcli/tests/test_docker.py
@@ -27,6 +27,27 @@ class TestDocker:
             call(['docker-compose', '-f', 'docker-compose.yml', 'stop'])
         ]
 
+    @patch('jbcli.utils.dockerutil.check_call')
+    @patch('jbcli.utils.dockerutil.glob')
+    def test_multiple_docker_compose_files(self, glob_mock, check_mock):
+        """When additional `docker-compose-*.yml` files are available, they
+        are passed to `docker-compose`.
+        """
+        glob_mock.return_value = [
+            'docker-compose-coolio.yml', 'docker-compose-2pac.yml']
+        dockerutil.up()
+        assert check_mock.mock_calls == [
+            call([
+                'docker-compose',
+                '-f', 'docker-compose.yml',
+                '-f', 'docker-compose-coolio.yml',
+                '-f', 'docker-compose-2pac.yml',
+                'up',
+            ])
+        ]
+
+
+
     @patch('jbcli.utils.dockerutil.client')
     def test_get_state_running(self, dockerutil_mock):
         Container = namedtuple('Container', ['status'])

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -2,6 +2,7 @@
 """
 from __future__ import print_function
 
+import glob
 import json
 import time
 from operator import itemgetter
@@ -34,20 +35,33 @@ class WatchHandler(FileSystemEventHandler):
         click.echo('Waiting for changes...')
 
 
+def _intersperse(el, l):
+    return [y for x in zip([el]*len(l), l) for y in x]
+
+
+def docker_compose(*args):
+    file_args = _intersperse('-f', glob.glob('docker-compose-*.yml'))
+    cmd = (
+        ['docker-compose', '-f', 'docker-compose.yml'] + file_args + list(args)
+    )
+
+    return check_call(cmd)
+
+
 def up():
     """Starts and optionally creates a Docker environment based on
     docker-compose.yml """
-    check_call(['docker-compose', 'up'])
+    docker_compose('up')
 
 
 def destroy():
     """Removes all containers and networks defined in docker-compose.yml"""
-    check_call(['docker-compose', 'down'])
+    docker_compose('down')
 
 
 def halt():
     """Halts all containers defined in docker-compose file."""
-    check_call(['docker-compose', 'stop'])
+    docker_compose('stop')
 
 
 def is_running():

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -2,7 +2,7 @@
 """
 from __future__ import print_function
 
-import glob
+from glob import glob
 import json
 import time
 from operator import itemgetter
@@ -40,7 +40,7 @@ def _intersperse(el, l):
 
 
 def docker_compose(*args):
-    file_args = _intersperse('-f', glob.glob('docker-compose-*.yml'))
+    file_args = _intersperse('-f', glob('docker-compose-*.yml'))
     cmd = (
         ['docker-compose', '-f', 'docker-compose.yml'] + file_args + list(args)
     )


### PR DESCRIPTION
Ticket: None (drive-by improvement)
Type: Improvement

#### This PR introduces the following changes

Whenever calling `docker-compose`, in addition to using `docker-compose.yml`, also pass all files that match `docker-compose-*.yml`.

This allows me to override specific things in my own files without having an outstanding diff in my working copy. For example, on Windows, when using the core environment, I override the way that the `fruition` repo is mounted into the juicebox container. With this change, I can now do this by adding a `docker-compose-radix.yml` file and add that file to my `.git/info/exclude` so I don't have to see outstanding changes whenever I'm using `git status` or `git diff`.
