### PR TITLE
Reduce npm-related repo clutter

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -330,7 +330,7 @@ def yo_upgrade():
     try:
         # Get the latest generator-juicebox
         output = subprocess.check_call(
-            ['npm', 'install', 'generator-juicebox'])
+            ['npm', 'install', '--package-lock=false', 'generator-juicebox'])
         click.echo(output)
         echo_success('Updated yo juicebox successfully')
 

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -622,7 +622,7 @@ class TestDocker:
 
         # TODO: Improve these tests
         assert proc_mock.mock_calls == [
-            call.check_call(['npm', 'install', 'generator-juicebox']),
+            call.check_call(['npm', 'install', '--package-lock=false', 'generator-juicebox']),
             call.check_call().__unicode__()
         ]
         # assert result.exit_code == 0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/juiceinc/devlandia.git"
   },
   "dependencies": {
-    "generator-juicebox": "juiceinc/generator-juicebox.git"
+    "generator-juicebox": "github:juiceinc/generator-juicebox"
   },
   "engines": {
     "npm": ">= 5.4"


### PR DESCRIPTION
Ticket: None
Type: Improvement

#### This PR introduces the following changes

- when running `jb start`, `npm` is now invoked with `--package-lock=false`. Given that we don't commit package-lock.json, and we even forcefully ignore it by running `npm install` all the time, there's no reason for us to produce it.
- recent versions of npm are forcefully switching us to the `github:` syntax for dependencies. This syntax has existed since 2.8.0 (released in 2015), so it should be safe to commit this change.

