### PR TITLE
remove dependency on maya because it's messing up CI

### DIFF
--- a/jbcli/requirements.txt
+++ b/jbcli/requirements.txt
@@ -1,4 +1,3 @@
-maya==0.3.3
 botocore==1.5.76
 docker==2.2.1
 docker-compose==1.12.0

--- a/jbcli/setup.py
+++ b/jbcli/setup.py
@@ -11,7 +11,6 @@ requirements = [
     'docker-compose==1.12.0',
     'botocore==1.5.76',
     'watchdog==0.8.3',
-    'maya==0.3.3',
     'tabulate==0.8.2'
 ]
 


### PR DESCRIPTION
Ticket: None
Type: Fix

#### This PR introduces the following changes

My PR at #33 was failing CI consistently because of weirdness happening with maya -> pendulum dependencies. I've filed a bug on pendulum here: https://github.com/sdispater/pendulum/issues/337

But our usage of maya in jbcli is very tiny and the easiest thing I could figure out for now is to just remove the dependency on it.

This does introduce a slight change in behavior: instead of showing "1 week ago" the code will now always print the delta in terms of days, e.g. "7 days ago".

