### PR TITLE
Pass the --mode option to webpack

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -261,4 +261,4 @@ def jb_watch(app=''):
 
 def js_watch():
     if is_running() and ensure_home():
-        run('./node_modules/.bin/webpack --progress --colors --watch')
+        run('./node_modules/.bin/webpack --mode=development --progress --colors --watch')


### PR DESCRIPTION
Ticket: None
Type: Improvement

#### This PR introduces the following changes

- Explicitly specify `--mode=development` as an option to webpack when running the js watcher.

## Documentation
We currently have a [PR](https://github.com/juiceinc/fruition/pull/1411) to update the version of Webpack to v4. In v4 the default "mode" is production. But when running the watcher we want the mode to be development.

## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
