### PR TITLE
[JB-2253] Add jb search command

### DIFF
--- a/jbcli/docs/usage.rst
+++ b/jbcli/docs/usage.rst
@@ -333,6 +333,46 @@ Example::
     $ jb start --noupdate
 
 
+search
+------
+
+This command will search juicebox elasticsearch logs. To use this you will need
+a username and password to either the core juicebox elasticsearch logging cluster
+or to a client juicebox logging cluster.
+
+To use, set the following environment variables:
+
+* LP_USERNAME (for legacy-staging, legacy-prod, staging, prod)
+* LP_PASSWORD
+* HSL_USERNAME (for hstm-qa and hstm-prod)
+* HSL_PASSWORD
+
+Options
+~~~~~~~
+
+.. csv-table::
+   :header: "Option", "Description"
+   :widths: 15, 30
+
+   "--username","Elasticsearch username if environment variables are not set"
+   "--password","Elasticsearch password if environment variables are not set"
+   "--env","Which environment to target"
+   "--data_service_log","Log type, one of performance, params, recipe"
+   "--env","Which environment to target"
+   "--lookback_window","Number of days to look at, only 90 days of history are retained"
+   "--limit","Number of records to return"
+   "--service_pattern","A regular expression that the service must match"
+   "--user_pattern","A regular expression that the user must match"
+   "--output","A filename to write the output to, if empty, will write to screen"
+
+
+
+Example::
+
+    $ jb search
+    [fill out the prompts]
+
+
 
 Built-in Help
 =============

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -14,6 +14,7 @@ from botocore import exceptions
 
 from ..utils import apps, dockerutil, subprocess
 from ..utils.format import echo_highlight, echo_warning, echo_success
+from ..utils.juice_log_searcher import JuiceboxLoggingSearcher
 
 """
 This is the code for the jb cli command.
@@ -428,3 +429,92 @@ def manage(args):
     except docker.errors.APIError:
         echo_warning('Could not clear cache')
         click.get_current_context().abort()
+
+
+@cli.command()
+@click.option(
+    '--username',
+    required=True,
+    envvar='LP_USERNAME',
+    help=
+    'Username for lp.juiceboxdata.com, must be passed or defined in '
+    'environment variable LP_USERNAME for core environments and '
+    'HSL_USERNAME for hstm environments'
+)
+@click.option(
+    '--password',
+    required=True,
+    envvar='LP_PASSWORD',
+    help=
+    'Password for lp.juiceboxdata.com, must be passed or defined in '
+    'environment variable LP_PASSWORD for core environments and '
+    'HSL_PASSWORD for hstm environments'
+)
+@click.option(
+    '--env',
+    prompt='Environment',
+    default='legacy-prod',
+    type=click.Choice(
+        ['legacy-staging', 'legacy-prod', 'prod', 'hstm-qa', 'hstm-prod']),
+    help='Environment to search, one of dev, staging, prod')
+@click.option(
+    '--data_service_log',
+    prompt='Log type',
+    type=click.Choice(['performance', 'params', 'recipe']),
+    default='performance',
+    help='Data service log type, one of performance, params, recipe')
+@click.option(
+    '--lookback_window',
+    prompt='Number of days',
+    default=10,
+    help='Number of days to look at')
+@click.option(
+    '--limit', prompt='Limit', default=100, help='Number of records to return')
+@click.option(
+    '--service_pattern',
+    prompt='Service pattern regular expression',
+    default='.*',
+    help='Data service regex to filter on')
+@click.option(
+    '--user_pattern',
+    prompt='User regular expression',
+    default='.*',
+    help='User regex to filter on')
+@click.option(
+    '--output',
+    prompt='A filename to write the output to',
+    default='',
+    help='A filename to write the output to')
+def search(username, password, env, data_service_log,
+                        lookback_window, limit, service_pattern, user_pattern,
+                        output):
+    """Query elasticsearch and show results
+
+    Environment variables LP_USERNAME and LP_PASSWORD must be set.
+    For healthstream account HSL_USERNAME and HSL_PASSWORD must be set.
+    """
+    if not username or not password:
+        print("Logging proxy username and password must be defined")
+
+    params = {
+        'username': username,
+        'password': password,
+        'env': env,
+        'data_service_log': data_service_log,
+        'lookback_window': lookback_window,
+        'limit': limit,
+        'service_pattern': service_pattern,
+        'user_pattern': user_pattern
+    }
+    dataset = JuiceboxLoggingSearcher().dataset(**params)
+
+    print(
+        'Running\njb search --env {env} --data_service_log {data_service_log} --lookback_window {lookback_window} --limit {limit} --service_pattern "{service_pattern}" --user_pattern "{user_pattern}" --output "{output}"\n\n'
+            .format(output=output, **params))
+
+    if output:
+        print('Writing {}'.format(output))
+        with open(output, 'w') as outf:
+            outf.write(dataset.tsv)
+    else:
+        print(dataset.tsv)

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -521,3 +521,6 @@ def search(username, password, env, data_service_log,
             outf.write(dataset.tsv)
     else:
         print(dataset.tsv)
+
+    if lookback_window > 90:
+        print("There is only 90 days of history retained")

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -486,8 +486,8 @@ def manage(args):
     default='',
     help='A filename to write the output to')
 def search(username, password, env, data_service_log,
-                        lookback_window, limit, service_pattern, user_pattern,
-                        output):
+           lookback_window, limit, service_pattern, user_pattern,
+           output):
     """Query elasticsearch and show results
 
     Environment variables LP_USERNAME and LP_PASSWORD must be set.
@@ -509,7 +509,10 @@ def search(username, password, env, data_service_log,
     dataset = JuiceboxLoggingSearcher().dataset(**params)
 
     print(
-        'Running\njb search --env {env} --data_service_log {data_service_log} --lookback_window {lookback_window} --limit {limit} --service_pattern "{service_pattern}" --user_pattern "{user_pattern}" --output "{output}"\n\n'
+        'Running\njb search --env {env} --data_service_log {data_service_log} '
+        '--lookback_window {lookback_window} --limit {limit} '
+        '--service_pattern "{service_pattern}" '
+        '--user_pattern "{user_pattern}" --output "{output}"\n\n'
             .format(output=output, **params))
 
     if output:

--- a/jbcli/jbcli/tests/test_juice_log_searcher.py
+++ b/jbcli/jbcli/tests/test_juice_log_searcher.py
@@ -1,0 +1,96 @@
+import mock
+import os
+from mock import call, patch
+
+from ..utils.juice_log_searcher import JuiceboxLoggingSearcher
+
+
+class TestJuiceboxLoggingSearcher:
+    def test_parse_log_parts(self):
+        searcher = JuiceboxLoggingSearcher()
+        d = searcher._parse_log_parts('performance', 'a=b c=d')
+        assert d == {'a': 'b', 'c': 'd'}
+
+    def test_parse_log_parts_performance(self):
+        searcher = JuiceboxLoggingSearcher()
+        line = '''2019-04-15 00:00:13,950 [DEBUG] dataservices.performance: service_id=jb3:1a561d1e-a82d-430f-b639-93bf2481d534 user=timothy.schailey@jefferson.edu service=apps.caygd.stacks.trend.trendservice.LeaderboardService totaltime=6.551'''
+        d = searcher._parse_log_parts('performance', line)
+        assert d == {
+            'totaltime': 6.551,
+            'service_id': 'jb3:1a561d1e-a82d-430f-b639-93bf2481d534',
+            'user': 'timothy.schailey@jefferson.edu',
+            'service':
+            'apps.caygd.stacks.trend.trendservice.LeaderboardService'
+        }
+
+    def test_parse_log_parts_recipe(self):
+        searcher = JuiceboxLoggingSearcher()
+        line = '''2019-04-17 00:02:20,305 [DEBUG] dataservices.recipe: service_id=jb3:6642a50c-325b-4c65-9360-3ca73298e1c0 user=binh.chung@juiceanalytics.com service=apps.preverity.stacks.individual.individualservice.RankedListService rows=8 db=0.018 enchant=0.000 cached=True  QUERYSTART SELECT juice.model_features.feature_friendly_name AS feature_friendly_name_id, juice.model_features.feature_friendly_name AS feature_friendly_name, juice.model_features.feature_name AS feature_name_id, juice.model_features.feature_name AS feature_name, juice.model_features.feature_order AS feature_order_id, juice.model_features.feature_order AS feature_order, max(juice.model_features.feature_value) AS feature_value FROM juice.model_features WHERE juice.model_features.npi = '1003809583' AND juice.model_features.prediction_year IN (2018) GROUP BY juice.model_features.feature_friendly_name, juice.model_features.feature_name, juice.model_features.feature_order ORDER BY juice.model_features.feature_order QUERYEND'''
+        d = searcher._parse_log_parts('recipe', line)
+        assert d == {
+            'db':
+            0.018,
+            'query':
+            "SELECT juice.model_features.feature_friendly_name AS feature_friendly_name_id, juice.model_features.feature_friendly_name AS feature_friendly_name, juice.model_features.feature_name AS feature_name_id, juice.model_features.feature_name AS feature_name, juice.model_features.feature_order AS feature_order_id, juice.model_features.feature_order AS feature_order, max(juice.model_features.feature_value) AS feature_value FROM juice.model_features WHERE juice.model_features.npi = '1003809583' AND juice.model_features.prediction_year IN (2018) GROUP BY juice.model_features.feature_friendly_name, juice.model_features.feature_name, juice.model_features.feature_order ORDER BY juice.model_features.feature_order ",
+            'rows':
+            8,
+            'service':
+            'apps.preverity.stacks.individual.individualservice.RankedListService',
+            'service_id':
+            'jb3:6642a50c-325b-4c65-9360-3ca73298e1c0',
+            'user':
+            'binh.chung@juiceanalytics.com'
+        }
+
+    def test_parse_log_parts_recipe_noquerymarkers(self):
+        searcher = JuiceboxLoggingSearcher()
+        line = '''2019-04-17 00:02:20,305 [DEBUG] dataservices.recipe: service_id=jb3:6642a50c-325b-4c65-9360-3ca73298e1c0 user=binh.chung@juiceanalytics.com service=apps.preverity.stacks.individual.individualservice.RankedListService rows=8 db=0.018 enchant=0.000 cached=True SELECT juice.model_features.feature_friendly_name AS feature_friendly_name_id, juice.model_features.feature_friendly_name AS feature_friendly_name, juice.model_features.feature_name AS feature_name_id, juice.model_features.feature_name AS feature_name, juice.model_features.feature_order AS feature_order_id, juice.model_features.feature_order AS feature_order, max(juice.model_features.feature_value) AS feature_value FROM juice.model_features WHERE juice.model_features.npi = '1003809583' AND juice.model_features.prediction_year IN (2018) GROUP BY juice.model_features.feature_friendly_name, juice.model_features.feature_name, juice.model_features.feature_order ORDER BY juice.model_features.feature_order'''
+        d = searcher._parse_log_parts('recipe', line)
+        assert d == {
+            'db':
+            0.018,
+            'query':
+            "SELECT juice.model_features.feature_friendly_name AS feature_friendly_name_id, juice.model_features.feature_friendly_name AS feature_friendly_name, juice.model_features.feature_name AS feature_name_id, juice.model_features.feature_name AS feature_name, juice.model_features.feature_order AS feature_order_id, juice.model_features.feature_order AS feature_order, max(juice.model_features.feature_value) AS feature_value FROM juice.model_features WHERE juice.model_features.npi = '1003809583' AND juice.model_features.prediction_year IN (2018) GROUP BY juice.model_features.feature_friendly_name, juice.model_features.feature_name, juice.model_features.feature_order ORDER BY juice.model_features.feature_order",
+            'rows':
+            8,
+            'service':
+            'apps.preverity.stacks.individual.individualservice.RankedListService',
+            'service_id':
+            'jb3:6642a50c-325b-4c65-9360-3ca73298e1c0',
+            'user':
+            'binh.chung@juiceanalytics.com'
+        }
+
+    def test_parse_log_parts_params(self):
+        searcher = JuiceboxLoggingSearcher()
+        line = '''2019-04-23 01:03:09,230 [DEBUG] dataservices.params: service_id=jb3:424b27e8-b122-4b02-9e62-b17eac1d88b8 user=taffe.bishop@tn.gov service=apps.tdoe_eplan.stacks.dashboard.dashboard_data_service.FilterService   User extra: { u'_initial_selections': { u'district_id': 700, u'school_id': u'700~0'}, u'_plan_external_id': u'5478', u'districts': [u'*'], u'is_priority': 0, u'schools': [u'*']} Request params: { u'benchmark_type': [u'benchmark'], u'district': [700], u'multiple_districts': [], u'school': [u'700~53']} Automatic filters: { 'district': [700], 'school': [u'700~53']} Custom filters: { 'benchmark_type': [u'benchmark'], 'district': [700], 'school': [u'700~53']}'''
+        d = searcher._parse_log_parts('params', line)
+        from pprint import pprint
+        pprint(d)
+        assert d == {
+            'automatic_filters':
+            "{ 'district': [700], 'school': [u'700~53']} ",
+            'custom_filters':
+            "{ 'benchmark_type': [u'benchmark'], 'district': [700], 'school': [u'700~53']}",
+            'request_params':
+            "{ u'benchmark_type': [u'benchmark'], u'district': [700], u'multiple_districts': [], u'school': [u'700~53']} ",
+            'service':
+            'apps.tdoe_eplan.stacks.dashboard.dashboard_data_service.FilterService',
+            'service_id':
+            'jb3:424b27e8-b122-4b02-9e62-b17eac1d88b8',
+            'user':
+            'taffe.bishop@tn.gov',
+            'user_extra':
+            "{ u'_initial_selections': { u'district_id': 700, u'school_id': u'700~0'}, u'_plan_external_id': u'5478', u'districts': [u'*'], u'is_priority': 0, u'schools': [u'*']} "
+        }
+
+    # @mock.patch.dict(os.environ, {'LP_USERNAME': 'foo', 'LP_PASSWORD': 'bar'})
+    # @patch('elasticsearch.Elasticsearch')
+    # @patch('elasticsearch_dsl.Search')
+    # def test_search(self, mock_search, mock_es):
+    #     mock_search.scan.return_value = []
+    #     searcher = JuiceboxLoggingSearcher()
+    #     searcher.search(username='foo', password='bar')
+    #
+    #     print(mock_es.mock_calls)
+    #     print(mock_search.mock_calls)

--- a/jbcli/jbcli/utils/juice_log_searcher.py
+++ b/jbcli/jbcli/utils/juice_log_searcher.py
@@ -1,0 +1,222 @@
+""" An elastic search class that queries juicebox logs """
+
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Search, Q
+
+try:
+    from urllib import quote_plus
+except ImportError:
+    from urllib.parse import quote_plus
+from os import environ
+import re
+import tablib
+
+# Extract timestamp, loglevel and data service log source
+prefix_pattern = re.compile('(.*)\ \[([A-Z]*)\]\ dataservices.(\w+)')
+# Extract part of the dataservices.params logs
+params_pattern = re.compile(
+    'User extra: (.*)Request params: (.*)Automatic filters: (.*)Custom filters: (.*)'
+)
+
+
+class JuiceboxLoggingSearcher(object):
+    def _parse_log_parts(self, data_service_log, parts):
+        """ Parse the log messages """
+        row = {}
+
+        # Each query contains data that looks like key=value key2=value2
+        # and sometimes extra data
+        if data_service_log == 'params':
+            kv_parts, extra_parts = parts.split('   ', 1)
+        elif data_service_log == 'recipe':
+            kv_parts, extra_parts = parts.split('SELECT ', 1)
+            extra_parts = 'SELECT ' + extra_parts
+            extra_parts = extra_parts.replace('QUERYEND', '')
+        elif data_service_log == 'performance':
+            kv_parts, extra_parts = parts, ''
+
+        # Handle the  key=value key2=value2 data
+        for part in parts.split(' '):
+            if part and '=' in part:
+                k, v = part.split('=')
+
+                # parse some values into numbers
+                if k == 'rows':
+                    v = int(v)
+                if k in ('enchant', 'db', 'totaltime'):
+                    v = float(v)
+                if k and v:
+                    row[k] = v
+
+        # Handle the log specific extra parts
+        if data_service_log == 'recipe':
+            row['query'] = extra_parts
+
+        elif data_service_log == 'params':
+            m = re.match(params_pattern, extra_parts)
+            if m:
+                user_extra, request_params, automatic_filters, custom_filters = m.groups(
+                )
+            else:
+                user_extra = request_params = automatic_filters = custom_filters = 'NOMATCH'
+            row['user_extra'] = user_extra
+            row['request_params'] = request_params
+            row['automatic_filters'] = automatic_filters
+            row['custom_filters'] = custom_filters
+        return row
+
+    def dataset(self, *args, **kwargs):
+        """Create a tablib dataset of a search"""
+        data = self.search(*args, **kwargs)
+
+        dataset = tablib.Dataset()
+
+        # Pull these keys to the front
+        initial_keys = [
+            'timestamp',
+            'service_id',
+            'service',
+            'user',
+            'environment',
+        ]
+        if data:
+            keys = list(
+                sorted([k for k in data[0].keys() if k not in initial_keys]))
+            initial_keys = [k for k in initial_keys if k in data[0].keys()]
+            dataset.headers = initial_keys + keys
+            for row in data:
+                values = [row.get(k) for k in dataset.headers]
+                dataset.append(values)
+
+        return dataset
+
+    def search(self,
+               username=None,
+               password=None,
+               env='legacy-prod',
+               service_pattern='.*',
+               user_pattern='.*',
+               data_service_log='performance',
+               lookback_window=10,
+               limit=100):
+        """Return some data as a list of dicts
+
+        :param username: The username used to connect to elasticsearch
+        :param password: The password used to connect to elasticsearch
+        :param env: can be one of 'legacy-staging', 'legacy-prod', 'prod', 'hstm-qa', 'hstm-prod', determines the elasticsearch server to connect to and
+        environment to hit
+        :param service_pattern: a regex pattern that the data service must match
+        :param user_pattern: a regex pattern that the user must match
+        :param data_service_log: one of recipe, performance, params
+            recipe: sql queries that were run and their runtime and number of rows returned
+            params: parameters passed to a data service and user extra
+            performance: how long the data service took to run
+        :param lookback_window: a number of days to get history for
+        :param limit: how many rows to return, 0 returns all rows
+        """
+        assert (data_service_log in ('recipe', 'performance', 'params'))
+
+        service_pattern = re.compile(service_pattern)
+        user_pattern = re.compile(user_pattern)
+
+        # TODO: We could do so much more with this query
+        q = Q(
+            'bool',
+            filter=[
+                Q(
+                    'range', **{
+                        '@timestamp': {
+                            'gte': 'now-{}d'.format(lookback_window),
+                            'lt': 'now'
+                        }
+                    }),
+                Q(
+                    'simple_query_string', **{
+                        "query": 'dataservices.{}'.format(data_service_log),
+                        "fields": ["message"],
+                    }),
+            ])
+
+        if env.startswith('hstm'):
+            username = quote_plus(environ.get('HSL_USERNAME') or username)
+            password = quote_plus(environ.get('HSL_PASSWORD') or password)
+            client = Elasticsearch([
+                'https://{}:{}@hsl.juiceboxdata.com:443'.format(
+                    username, password)
+            ])
+            filter_type = 'log'
+        else:
+            username = quote_plus(environ.get('LP_USERNAME') or username)
+            password = quote_plus(environ.get('LP_PASSWORD') or password)
+            client = Elasticsearch([
+                'https://{}:{}@lp.juiceboxdata.com:443'.format(
+                    username, password)
+            ])
+            filter_type = 'jb_data_services'
+
+        search = Search(index='logstash-*') \
+            .using(client) \
+            .filter('term', type=filter_type) \
+            .sort('@timestamp', {"lines": {"order": "asc"}}) \
+            .query(q)
+
+        # Adapt search queries to target the right environment
+        if env == 'hstm-qa':
+            pass
+            # TODO: come up with a better way of filtering to staging
+            # These are filtered when iterating over results by looking
+            # at beat.hostname.
+        elif env == 'hstm-prod':
+            pass
+            # TODO: come up with a better way of filtering to prod
+            # These are filtered when iterating over results by looking
+            # at beat.hostname.
+        elif env == 'legacy-staging':
+            search = search.filter('term', **{
+                'fields.env': 'staging'
+            }).filter(
+                'term', environment='legacy')
+        elif env == 'legacy-prod':
+            search = search.filter('term', **{
+                'fields.env': 'prod'
+            }).filter(
+                'term', environment='legacy')
+        elif env == 'prod':
+            search = search.filter('term', environment='prod')
+
+        results = []
+        cnt = 0
+        for hit in search.scan():
+            if limit and cnt >= limit:
+                break
+
+            # Filter hstm rows, would be better to do this in the ES query
+            if env == 'hstm-prod' and 'prod' not in hit.beat.hostname:
+                continue
+            if env == 'hstm-qa' and 'staging' not in hit.beat.hostname:
+                continue
+
+            # prefix = 2019-04-16 01:08:25,794 [DEBUG] dataservices.params:
+            # parts = data about this request
+            prefix, parts = hit.message.split(': ', 1)
+
+            prefix_match = re.match(prefix_pattern, prefix)
+            ts, level, data_service_log = prefix_match.groups()
+
+            # Parse the log message into a dictionary
+            # Get the timestamp and the debug level
+            row = {
+                'timestamp': ts,
+                'environment': hit.environment,
+                'data_service_log': data_service_log
+            }
+            row.update(self._parse_log_parts(data_service_log, parts))
+
+            # Filter to a specific service pattern
+            if re.match(service_pattern, row.get('service', '')) and \
+                    re.match(user_pattern, row.get('user', '')):
+                cnt += 1
+                results.append(row)
+
+        return results
+

--- a/jbcli/jbcli/utils/juice_log_searcher.py
+++ b/jbcli/jbcli/utils/juice_log_searcher.py
@@ -48,6 +48,10 @@ class JuiceboxLoggingSearcher(object):
                 if k and v:
                     row[k] = v
 
+        # Remove a non-useful cached property from recipe
+        # logs. This seems to be always "True"
+        row.pop('cached', None)
+
         # Handle the log specific extra parts
         if data_service_log == 'recipe':
             row['query'] = extra_parts

--- a/jbcli/requirements.txt
+++ b/jbcli/requirements.txt
@@ -7,3 +7,7 @@ gabbi==1.24.0
 requests==2.11.1
 watchdog==0.8.3
 tabulate==0.8.2
+certifi==2019.3.9
+elasticsearch==6.3.1
+elasticsearch-dsl==6.3.1
+tablib==0.13.0


### PR DESCRIPTION
Ticket: [JB-2253](https://juiceanalytics.atlassian.net/browse/JB-2253)
Type: Feature

#### This PR introduces the following changes

- Adds a search subcommand to search juice elasticsearch logging for both core and hstm

## Documentation

If this is a new feature, document its usage here. Use screenshots and/or code snippets is appreciated!

## Checklist

- [ ] Add information to the release notes documentation
- [x] Add new feature to the usage documentation
- [x] Add tests
