### PR TITLE
Add jb stop cli command

### DIFF
--- a/jbcli/docs/usage.rst
+++ b/jbcli/docs/usage.rst
@@ -333,6 +333,19 @@ Example::
     $ jb start --noupdate
 
 
+stop
+----
+
+This command will stop your Juicebox VM if it is already running.
+
+Options
+~~~~~~~
+
+None
+
+Example::
+
+    $ jb stop
 
 Built-in Help
 =============

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -322,6 +322,20 @@ def start(ctx, noupdate, noupgrade):
 
 
 @cli.command()
+@click.pass_context
+def stop(ctx):
+    """Stop a running juicebox in this environment
+    """
+    dockerutil.ensure_home()
+
+    if not dockerutil.is_running():
+        echo_highlight('Juicebox is not running')
+    else:
+        dockerutil.halt()
+        echo_highlight('Juicebox is no longer running.')
+
+
+@cli.command()
 def yo_upgrade():
     """ Attempt to upgrade yo juicebox to the current version
     """

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -448,6 +448,20 @@ class TestDocker:
         assert result.exit_code == 0
 
     @patch('jbcli.cli.jb.dockerutil')
+    def test_stop(self, dockerutil_mock):
+        dockerutil_mock.is_running.return_value = True
+        dockerutil_mock.ensure_home.return_value = True
+        dockerutil_mock.halt.return_value = None
+        runner = CliRunner()
+        result = runner.invoke(cli, ['stop'])
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.ensure_home(),
+            call.is_running(),
+            call.halt()
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
     def test_start(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
         dockerutil_mock.ensure_home.return_value = True


### PR DESCRIPTION
Ticket: None
Type: Improvement

#### This PR introduces the following changes

- Adds a `jb stop` command

## Documentation

Because sometimes you don't want to go, you want to stop.

## Checklist

- [ ] Add information to the release notes documentation
- [x] Add new feature to the usage documentation
- [x] Add tests
