### PR TITLE
Improve watcher for jb4 apps

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -29,10 +29,13 @@ class WatchHandler(FileSystemEventHandler):
             path = re.split(r'[\\/]', event.src_path)
         else:
             path = event.src_path.split('/')
-        click.echo('Change detected in app: {}.'.format(path))
+        click.echo('Change detected in app: {}.'.format(event.src_path))
 
-        if path[-1] != '.git':
+        # Ignore .git files and the entire builds directory
+        if '.git' not in path and 'builds' not in path:
             run('/venv/bin/python manage.py loadjuiceboxapp ' + path[3])
+        else:
+            click.echo('Change ignored')
 
         click.echo('Waiting for changes...')
 


### PR DESCRIPTION
Watcher was running repeatedly due to builds/full-app.yaml being created

Ticket: None
Type: Fix


## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
