### PR TITLE
Fix watcher for jb4 apps

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -29,10 +29,12 @@ class WatchHandler(FileSystemEventHandler):
             path = re.split(r'[\\/]', event.src_path)
         else:
             path = event.src_path.split('/')
-        click.echo('Change detected in app: {}.'.format(path))
+        click.echo('Change detected in app: {}.'.format(event.src_path))
 
-        if path[-1] != '.git':
+        if '.git' not in path and 'builds' not in path:
             run('/venv/bin/python manage.py loadjuiceboxapp ' + path[3])
+        else:
+            click.echo('Change ignored')
 
         click.echo('Waiting for changes...')
 


### PR DESCRIPTION
Ticket: None
Type: Fix

#### This PR introduces the following changes

- Watcher was running repeatedly in jb4 apps because loading the app creates info at `builds/full-app.yaml`

## Documentation

If this is a new feature, document its usage here. Use screenshots and/or code snippets is appreciated!

## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
