### PR TITLE
With docker upgrade, we can get generators back, print them correctly

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from glob import glob
 import json
 import time
+import types
 from operator import itemgetter
 import datetime
 from watchdog.events import FileSystemEventHandler
@@ -147,7 +148,11 @@ def run(command):
             juicebox = client.containers.get(container.name)
             command_run = juicebox.exec_run(command, stream=True)
             for output in command_run:
-                print(output)
+                if isinstance(output, types.GeneratorType):
+                    for o in output:
+                        print(o)
+                else:
+                    print(output)
 
 
 def parse_dc_file(tag):


### PR DESCRIPTION
Ticket: OPS-1708
Type: Fix

#### This PR introduces the following changes

- Fix an issue w output not displaying in jb commands

## Documentation

None

## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
