### PR TITLE
fix a misleading log message about "Signature expired" messages

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -312,13 +312,15 @@ def start(ctx, noupdate, noupgrade):
                 dockerutil.pull(tag=None)
             dockerutil.up(env=populate_env_with_secrets())
         except botocore.exceptions.ClientError as e:
-            click.echo(
-                "Encountered Signature expired exception.  Attempting to restart Docker, please wait...")
             if "Signature expired" in e.message:
+                click.echo(
+                    "Encountered Signature expired exception.  Attempting to restart Docker, please wait...")
                 subprocess.check_call(
                     ['killall', '-HUP' 'com.docker.hyperkit'])
                 time.sleep(30)
                 start(noupdate=noupdate)
+            else:
+                raise
     else:
         echo_warning('An instance of Juicebox is already running')
 


### PR DESCRIPTION
Ticket: N/A quick fix

## Changes

The code was previously logging that it found a "Signature expired" message before even checking if it ACTUALLY found a "Signature expired" message.

Change this to only log that message if we actually found one, and reraise the error if it's not one.