### PR TITLE
[JB-2454] pass opslord github credentials to devlandia so it can fetch apps from github

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
       - JB_GOOGLE_CLOUD_PRIVKEY
+      - JB_GITHUB_FETCHAPP_CREDS
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -328,6 +328,7 @@ def start(ctx, noupdate, noupgrade):
 def populate_env_with_secrets():
     env = os.environ.copy()
     env['JB_GOOGLE_CLOUD_PRIVKEY'] = get_paramstore('jbo-google-cloud-privkey')
+    env['JB_GITHUB_FETCHAPP_CREDS'] = get_paramstore('opslord-github-credentials')
     return env
 
 


### PR DESCRIPTION
Ticket: [JB-2454](https://juiceanalytics.atlassian.net/browse/JB-2454)
Type: Feature

## Changes

- pass the `opslord-github-credentials` parameter store value to the devlandia container as `JB_GITHUB_FETCHAPP_CREDS`.

This corresponds to fruition PR juiceinc/fruition#1622.

