### PR TITLE
Feature/[JB-2481] jb upload command

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -73,6 +73,31 @@ def package(applications, bucket):
 
 
 @cli.command()
+@click.argument('datafile', 
+                nargs=1, 
+                required=True)
+@click.option('--app', help='The app to upload data to', required=True)
+def upload(datafile, app):
+    """Upload data to a juicebox app 
+    """
+    if dockerutil.is_running() and dockerutil.ensure_home():
+        failed_apps = []
+        try:
+            echo_highlight('Uploading...'.format(app))
+            dockerutil.run(
+                '/venv/bin/python manage.py upload --app={} {}'.format(
+                    app, datafile))
+
+        except docker.errors.APIError:
+            print(docker.errors.APIError.message)
+            failed_apps.append(app)
+    else:
+        echo_warning(
+            'Juicebox is not running or you\'re not in a home directory.')
+        click.get_current_context().abort()
+
+
+@cli.command()
 @click.argument('applications', nargs=-1, required=True)
 @click.option('--add-desktop/--no-add-desktop', default=False,
               help='Optionally add to Github Desktop')

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -73,9 +73,7 @@ def package(applications, bucket):
 
 
 @cli.command()
-@click.argument('datafile', 
-                nargs=1, 
-                required=True)
+@click.argument('datafile', nargs=1, required=True)
 @click.option('--app', help='The app to upload data to', required=True)
 def upload(datafile, app):
     """Upload data to a juicebox app 

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -141,6 +141,24 @@ class TestDocker(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     @patch('jbcli.cli.jb.os')
+    def test_upload(self, os_mock, dockerutil_mock):
+        os_mock.path.isdir.return_value = False
+        dockerutil_mock.is_running.return_value = True
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ['upload', '--app=foo', 'cookies.csv'])
+
+        assert 'Uploading...' in result.output
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.is_running(),
+            call.ensure_home(),
+            call.ensure_home().__nonzero__(),
+            call.run('/venv/bin/python manage.py upload --app=foo cookies.csv')
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
+    @patch('jbcli.cli.jb.os')
     def test_add_app_exists(self, os_mock, dockerutil_mock):
         os_mock.path.isdir.return_value = True
         dockerutil_mock.is_running.return_value = True

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -150,9 +150,11 @@ def run(command):
             for output in command_run:
                 if isinstance(output, types.GeneratorType):
                     for o in output:
-                        print(o)
+                        if o is not None:
+                            print(o)
                 else:
-                    print(output)
+                    if output is not None:
+                        print(output)
 
 
 def parse_dc_file(tag):


### PR DESCRIPTION
Ticket: [JB-2481](https://juiceanalytics.atlassian.net/browse/JB-2481)
Type: Feature

#### This PR introduces the following changes

- Adds `jb upload` command that hooks into django management upload command

## Documentation

Upload allows an app developer to save a csv to a bigquery table. This is a jbcli frontend that passes directly to the django management command that performs the upload.

```
Usage: jb upload [OPTIONS] DATAFILE

  Upload data to a juicebox app

Options:
  --app TEXT  The app to upload data to  [required]
  --help      Show this message and exit.
```


## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
