### PR TITLE
[JB-1722 ] New style jb start

### DIFF
--- a/environments/core/fruition
+++ b/environments/core/fruition
@@ -1,1 +1,0 @@
-/Users/david.paul/Desktop/fruition

--- a/environments/core/fruition
+++ b/environments/core/fruition
@@ -1,0 +1,1 @@
+/Users/david.paul/Desktop/fruition

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -494,13 +494,11 @@ def freshstart(ctx, env, noupdate, noupgrade):
         echo_highlight('No environment selected.')
         return
 
-    os.chdir("./environments/{}".format(env))
-
     if not noupgrade:
-        cwd = os.getcwd()
-        os.chdir(os.path.join(cwd, '..', '..'))
         ctx.invoke(upgrade)
-        os.chdir(cwd)
+
+    stash.put('current_env', env)
+    os.chdir("./environments/{}".format(env))
 
     try:
         if not noupdate:

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -11,7 +11,7 @@ import botocore
 import click
 import docker.errors
 from botocore import exceptions
-from PyInquirer import prompt
+from PyInquirer import prompt, Separator
 
 from ..utils import apps, dockerutil, jbapiutil, subprocess
 from ..utils.format import echo_highlight, echo_warning, echo_success, human_readable_timediff
@@ -290,34 +290,94 @@ def ls(showall=False, semantic=False):
         echo_warning('You must login to the registry first.')
 
 
-@click.argument('tag', nargs=1, required=True)
+@click.option('--showall', default=False, help='Show all tagged images',
+              is_flag=True)
+@click.option('--env', default=None, help='Select in this environment')
+@click.argument('tag', nargs=1, required=False)
 @cli.command()
-def select(tag):
+def select(tag, env=None, showall=False):
     """Select tagged image to use
     """
     found = False
-    if dockerutil.ensure_test_core():
-        tags = dockerutil.image_list(print_flag=False, showall=True)
-        for tagset in tags:
-            if tag in tagset[0]:
+    questions = []
+    if tag is None:
+        click.echo('Gathering data on available tags...\n')
+        tag_choices = []
+        prev_priority = None
+        for row in dockerutil.image_list(print_flag=False, showall=showall):
+            tag, pushed, human_readable, tag_priority, is_semantic_tag, stable_version = row
+            if prev_priority and prev_priority != tag_priority:
+                tag_choices.append(Separator())
+            tag_choices.append({
+                'name': '{} (published {})'.format(tag, human_readable), 
+                'value': tag
+            })
+            prev_priority = tag_priority
 
+        questions.append(
+            {
+                'type': 'list',
+                'name': 'tag',
+                'message': 'What tag would you like to select?',
+                'choices': tag_choices
+            }
+        )
+        found = True
+
+    if env is None:
+        questions.append(
+            {
+                'type': 'list',
+                'name': 'env',
+                'message': 'What environment would you like to change?',
+                'choices': ['test', 'core', 'hstm-test', 'hstm-core']
+            }
+        )
+
+
+    response = prompt(questions)
+    tag = response.get('tag', tag)
+    env = response.get('env', env)
+
+    if tag is None:
+        echo_highlight('No tag selected.')
+        return
+
+    if env is None:
+        echo_highlight('No environment selected.')
+        return
+
+    os.chdir("./environments/{}".format(env))
+
+    if not found:
+        click.echo('Checking this tag is valid...\n')
+        for img in dockerutil.image_list(showall=True, print_flag=False):
+            if tag == img[0]:
                 found = True
-                stash.put('jb_select', tag)
-                dockerutil.pull(tag)
-                with open("./docker-compose.yml", "rt") as dc:
-                    with open("out.txt", "wt") as out:
-                        for line in dc:
-                            if 'juicebox-devlandia:' in line:
-                                oldTag = line.rpartition(':')[2]
-                                out.write(line.replace(oldTag, tag) + '\"\n')
-                            else:
-                                out.write(line)
-                shutil.move('./out.txt', './docker-compose.yml')
+                break
+    
+    if found:
+        jb_select = stash.get('jb_select', {})
+        if not isinstance(jb_select, dict):
+            jb_select = {
+                'test': jb_select
+            }
+        jb_select[env] = tag
+        stash.put('jb_select', jb_select)
+        # dockerutil.pull(tag)
+        with open("./docker-compose.yml", "rt") as dc:
+            with open("out.txt", "wt") as out:
+                for line in dc:
+                    if 'juicebox-devlandia:' in line:
+                        oldTag = line.rpartition(':')[2]
+                        out.write(line.replace(oldTag, tag) + '\"\n')
+                    else:
+                        out.write(line)
+        shutil.move('./out.txt', './docker-compose.yml')
+        echo_success('Environment {} will use {}'.format(env, tag))
 
-        if not found:
-            echo_warning('That tag doesn\'t exist.')
-    else:
-        echo_warning('This can only be done in the test or core environments.')
+    if not found:
+        echo_warning('That tag doesn\'t exist.')
 
 
 @cli.command()
@@ -366,6 +426,7 @@ def populate_env_with_secrets():
 
 
 @cli.command()
+@click.argument('env', nargs=1, required=False)
 @click.option('--noupdate', default=False,
               help='Do not automatically update Docker image on start',
               is_flag=True)
@@ -373,67 +434,74 @@ def populate_env_with_secrets():
               help='Do not automatically update jb and generators on start',
               is_flag=True)
 @click.pass_context
-def freshstart(ctx, noupdate, noupgrade):
+def freshstart(ctx, env, noupdate, noupgrade):
     """Configure the environment and start Juicebox
     """
     path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
     os.chdir(path)
-    click.echo("Welcome to devlandia!")
-    click.echo('Gathering data on available environments...\n')
-    # get a list of all the current images
-    stuff = dockerutil.image_list(print_flag=False, semantic=False)
-    # these are the tags we want to look for in the list of images
-    interesting_tags = ['develop', 'stable']
+    if env is None:
+        click.echo("Welcome to devlandia!")
+        click.echo('Gathering data on available environments...\n')
+        # get a list of all the current images
+        tags = dockerutil.image_list(showall=True, print_flag=False, semantic=False)
+        # these are the tags we want to look for in the list of images
 
-    test_tag = stash.get('jb_select')
-    if test_tag and test_tag not in interesting_tags:
-        interesting_tags.append(test_tag)
-        
-    # Generate suffixes for each environment that contain information on what image is
-    # associated with a tag, and when those images were published
-    extra_lookup = {}
-    stuff.sort(key=lambda x: x[2])
-    for prev_row, row in zip(stuff, stuff[1:]):
-        tag = row[0]
-        prevtag = prev_row[0]
-        readable_timediff = human_readable_timediff(row[2])
-        if tag in interesting_tags:
+        # Generate suffixes for each environment that contain information on what image is
+        # associated with a tag, and when those images were published
+        extra_lookup = {}
+
+        jb_select = stash.get('jb_select', {})
+        if not isinstance(jb_select, dict):
+            jb_select = {
+                'test': jb_select
+            }
+
+        for env, selected_tag in jb_select.items():
+            extra_lookup[env] = selected_tag
+
+        for row in tags:
+            tag, pushed, human_readable, tag_priority, is_semantic_tag, stable_version = row
+
             if tag == 'stable':
-                extra_lookup['stable'] = 'stable - ({}) published {}'.format(prevtag, readable_timediff)
-            if tag == test_tag:
-                extra_lookup['test'] = 'test - ({}) published {} (change this with jb select)'.format(test_tag, readable_timediff)
+                extra_lookup['stable'] = 'stable - ({}) published {}'.format(stable_version, human_readable)
             if tag == 'develop':
-                extra_lookup['dev'] = 'dev - (develop) published {}'.format(readable_timediff)
-                extra_lookup['core'] = 'core - (develop) published {}'.format(readable_timediff)
-    if 'test' not in extra_lookup:
-        extra_lookup['test'] = 'test - set with `jb select`'
+                extra_lookup['dev'] = 'dev - (develop) published {}'.format(human_readable)
+                extra_lookup['core'] = 'core - (develop) published {}'.format(human_readable)
+            for env, selected_tag in jb_select.items():
+                if tag == selected_tag:
+                    extra_lookup[env] = '{} - ({}, set with `jb select`) published {}'.format(env, selected_tag, human_readable)
 
-    click.echo()
+        if 'test' not in extra_lookup:
+            extra_lookup['test'] = 'test - set with `jb select`'
 
-    env_choices = [{'name': extra_lookup.get('stable', 'stable'), 'value': 'stable'},
-                   {'name': extra_lookup.get('dev', 'dev'), 'value': 'dev'},
-                   {'name': extra_lookup.get('core', 'core'), 'value': 'core'},
-                   {'name': extra_lookup.get('test', 'test'), 'value': 'test'},
-                   'hstm-stable', 'hstm-dev', 'hstm-core', 'hstm-test']
-    questions = [
-        {
-            'type': 'list',
-            'name': 'Environment',
-            'message': 'what environment would you like to start?',
-            'choices': env_choices
-        }
-    ]
+        env_choices = [
+            {'name': extra_lookup.get('stable', 'stable'), 'value': 'stable'},
+            {'name': extra_lookup.get('dev', 'dev'), 'value': 'dev'},
+            {'name': extra_lookup.get('core', 'core'), 'value': 'core'},
+            {'name': extra_lookup.get('test', 'test'), 'value': 'test'},
+            {'name': extra_lookup.get('hstm-stable', 'hstm-stable'), 'value': 'hstm-stable'},
+            {'name': extra_lookup.get('hstm-dev', 'hstm-dev'), 'value': 'hstm-dev'},
+            {'name': extra_lookup.get('hstm-core', 'hstm-core'), 'value': 'hstm-core'},
+            {'name': extra_lookup.get('hstm-test', 'hstm-test'), 'value': 'hstm-test'}
+        ]
+        
+        questions = [
+            {
+                'type': 'list',
+                'name': 'env',
+                'message': 'what environment would you like to start?',
+                'choices': env_choices
+            }
+        ]
 
-    response = prompt(questions)
-    env = response['Environment']
-    click.echo(response)
+        response = prompt(questions)
+        env = response.get('env', None)
 
-    if not noupgrade:
-        ctx.invoke(upgrade)
-        os.chdir("./environments/{}".format(env))
-    else:
-        os.chdir("./environments/{}".format(env))
+    if not env:
+        echo_highlight('No environment selected.')
+        return
 
+    os.chdir("./environments/{}".format(env))
     ctx.forward(start)
 
 

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -455,8 +455,8 @@ def freshstart(ctx, env, noupdate, noupgrade):
         for row in tags:
             tag, pushed, human_readable, tag_priority, is_semantic_tag, stable_version = row
 
-            if tag == 'stable':
-                extra_lookup['stable'] = 'stable - ({}) published {}'.format(stable_version, human_readable)
+            if tag == 'master':
+                extra_lookup['master'] = 'stable/master - ({}) published {}'.format(stable_version, human_readable)
             if tag == 'develop':
                 extra_lookup['dev'] = 'dev - (develop) published {}'.format(human_readable)
                 extra_lookup['core'] = 'core - (develop) published {}'.format(human_readable)
@@ -468,7 +468,7 @@ def freshstart(ctx, env, noupdate, noupgrade):
             extra_lookup['test'] = 'test - set with `jb select`'
 
         env_choices = [
-            {'name': extra_lookup.get('stable', 'stable'), 'value': 'stable'},
+            {'name': extra_lookup.get('master', 'master'), 'value': 'stable'},
             {'name': extra_lookup.get('dev', 'dev'), 'value': 'dev'},
             {'name': extra_lookup.get('core', 'core'), 'value': 'core'},
             {'name': extra_lookup.get('test', 'test'), 'value': 'test'},

--- a/jbcli/jbcli/tests/test_docker.py
+++ b/jbcli/jbcli/tests/test_docker.py
@@ -235,3 +235,12 @@ class TestDocker:
             [u'master', '30 seconds ago', 4, False, u'3.22.1'], 
             [u'3.22.1', '3 months ago', 2, True, None]
         ]
+
+        # Semantic flag gets only semantic tags
+        output = dockerutil.image_list(showall=True, print_flag=False, semantic=True)
+
+        for o in output:
+            o.pop(1)
+        assert output == [
+            [u'3.22.1', '3 months ago', 2, True, None]
+        ]

--- a/jbcli/jbcli/tests/test_format.py
+++ b/jbcli/jbcli/tests/test_format.py
@@ -1,6 +1,9 @@
 from mock import call, patch
 
-from ..utils.format import echo_success, echo_warning, echo_highlight
+from ..utils.format import (
+    echo_success, echo_warning, echo_highlight, human_readable_timediff
+)
+from datetime import datetime, timedelta
 
 
 class TestFormat:
@@ -25,3 +28,14 @@ class TestFormat:
         assert secho_mock.mock_calls == [
             call('COOKIES!', fg='red', bold=True)
         ]
+
+
+class TestTimeDiff:
+
+    def test_human_readable_timediff(self):
+        v = human_readable_timediff(datetime.now() - timedelta(minutes=30))
+        assert v == '30 minutes ago'
+
+        v = human_readable_timediff(datetime.now() - timedelta(days=2) - timedelta(minutes=30))
+        assert v == '2 days, 30 minutes ago'
+

--- a/jbcli/jbcli/tests/test_format.py
+++ b/jbcli/jbcli/tests/test_format.py
@@ -37,5 +37,7 @@ class TestTimeDiff:
         assert v == '30 minutes ago'
 
         v = human_readable_timediff(datetime.now() - timedelta(days=2) - timedelta(minutes=30))
-        assert v == '2 days, 30 minutes ago'
+        assert v == '2 days ago'
 
+        v = human_readable_timediff(datetime.now() - timedelta(days=1) - timedelta(minutes=30))
+        assert v == '1 day, 30 minutes ago'

--- a/jbcli/jbcli/tests/test_format.py
+++ b/jbcli/jbcli/tests/test_format.py
@@ -28,16 +28,3 @@ class TestFormat:
         assert secho_mock.mock_calls == [
             call('COOKIES!', fg='red', bold=True)
         ]
-
-
-class TestTimeDiff:
-
-    def test_human_readable_timediff(self):
-        v = human_readable_timediff(datetime.now() - timedelta(minutes=30))
-        assert v == '30 minutes ago'
-
-        v = human_readable_timediff(datetime.now() - timedelta(days=2) - timedelta(minutes=30))
-        assert v == '2 days ago'
-
-        v = human_readable_timediff(datetime.now() - timedelta(days=1) - timedelta(minutes=30))
-        assert v == '1 day, 30 minutes ago'

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -265,15 +265,17 @@ def image_list(showall=False, print_flag=True, semantic=False):
 
     # Find the semantic version of stable
     imageList.sort(key=itemgetter(1))
+
     newImageList = []
-    for prev_row, row in zip(imageList, imageList[1:]):
+    prevtag = None
+    for row in imageList:
         tag, pushed, human_readable, tag_priority, is_semantic_tag = row
-        prevtag = prev_row[0]
         if tag == 'master':
             row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, prevtag]
         else:
             row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, None]
         newImageList.append(row)
+        prevtag = tag
 
     # Sort in descending order of priority and timestamp
     def sort_order(row):

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -240,16 +240,15 @@ def image_list(showall=False, print_flag=True, semantic=False):
     for image in images['imageDetails']:
         if 'imageTags' in image:
             pushed = datetime.datetime.fromtimestamp(int(image['imagePushedAt']))
-            pushed = pushed + datetime.timedelta(hours=5) # Why do we add 5 hours?
             for tag in image['imageTags']:
                 slang = '{} days ago'.format((now - pushed).days)
                 if not showall and not semantic:
                     if pushed >= now - datetime.timedelta(days=30):
                         imageList.append(
-                            [tag, image['imageDigest'][7:], slang])
+                            [tag, image['imageDigest'][7:], pushed])
                 elif showall and not semantic:
                     imageList.append(
-                        [tag, image['imageDigest'][7:], slang])
+                        [tag, image['imageDigest'][7:], pushed])
                 elif semantic and not showall:
                     if '.' in tag:
                         imageList.append([tag, image['imageDigest'][7:],

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -245,7 +245,7 @@ def image_list(showall=False, print_flag=True, semantic=False):
             for tag in image['imageTags']:
                 human_readable = human_readable_timediff(pushed)
                 is_semantic_tag = bool(semantic_version_tag_pattern.match(tag))
-                if tag == 'stable':
+                if tag == 'master':
                     tag_priority = 4
                 elif tag == 'develop': 
                     tag_priority = 3
@@ -269,7 +269,7 @@ def image_list(showall=False, print_flag=True, semantic=False):
     for prev_row, row in zip(imageList, imageList[1:]):
         tag, pushed, human_readable, tag_priority, is_semantic_tag = row
         prevtag = prev_row[0]
-        if tag == 'stable':
+        if tag == 'master':
             row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, prevtag]
         else:
             row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, None]
@@ -283,7 +283,7 @@ def image_list(showall=False, print_flag=True, semantic=False):
     if print_flag:
         print(
             tabulate(newImageList,
-                headers=['Image Name', 'Time Tagged', 'Relative', 'Priority', 'Is Semantic', 'Stable Version']
+                headers=['Image Name', 'Time Tagged', 'Relative', 'Priority', 'Is Semantic', 'Master Version']
             )
         )
 

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -153,16 +153,6 @@ def ensure_home(output=True):
     return True
 
 
-def ensure_test_core():
-    """Verifies that we are in the Juicebox test directory
-
-    :rtype: ``bool``
-    """
-    if 'test' in os.getcwd() or 'core' in os.getcwd():
-        return True
-    return False
-
-
 def run(command):
     """Runs a command directly in the docker container.
     """

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -22,7 +22,7 @@ from .jbapiutil import load_app
 from .subprocess import check_call, check_output
 from .reload import refresh_browser
 
-from .format import echo_warning, echo_success
+from .format import echo_warning, echo_success, human_readable_timediff
 
 client = docker.from_env()
 
@@ -233,32 +233,60 @@ def pull(tag):
 
 def image_list(showall=False, print_flag=True, semantic=False):
     """Lists available tagged images"""
+    semantic_version_tag_pattern = re.compile('^\d+\.\d+\.\d+$')
     imageList = []
+    now = datetime.datetime.now()
     cmd = "aws ecr describe-images --registry-id 423681189101 --repository-name juicebox-devlandia"
     images = json.loads(check_output(cmd.split()))
-    now = datetime.datetime.now()
     for image in images['imageDetails']:
         if 'imageTags' in image:
             pushed = datetime.datetime.fromtimestamp(int(image['imagePushedAt']))
             for tag in image['imageTags']:
-                slang = '{} days ago'.format((now - pushed).days)
-                if not showall and not semantic:
-                    if pushed >= now - datetime.timedelta(days=30):
-                        imageList.append(
-                            [tag, image['imageDigest'][7:], pushed])
-                elif showall and not semantic:
-                    imageList.append(
-                        [tag, image['imageDigest'][7:], pushed])
-                elif semantic and not showall:
-                    if '.' in tag:
-                        imageList.append([tag, image['imageDigest'][7:],
-                                          slang])
+                human_readable = human_readable_timediff(pushed)
+                is_semantic_tag = bool(semantic_version_tag_pattern.match(tag))
+                if tag == 'stable':
+                    tag_priority = 4
+                elif tag == 'develop': 
+                    tag_priority = 3
+                elif is_semantic_tag:
+                    tag_priority = 2
+                else:
+                    tag_priority = 1
+
+                # If semantic, just return semantic tags
+                meets_semantic_criteria = (semantic and is_semantic_tag) or not semantic
+                # Use if showall is true, return all tags, otherwise return just last 30 days
+                meets_time_criteria = showall or (pushed >= now - datetime.timedelta(days=30))
+
+                if meets_semantic_criteria and meets_time_criteria:
+                    row = [tag, pushed, human_readable, tag_priority, is_semantic_tag]
+                    imageList.append(row)
+
+    # Find the semantic version of stable
+    imageList.sort(key=itemgetter(1))
+    newImageList = []
+    for prev_row, row in zip(imageList, imageList[1:]):
+        tag, pushed, human_readable, tag_priority, is_semantic_tag = row
+        prevtag = prev_row[0]
+        if tag == 'stable':
+            row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, prevtag]
+        else:
+            row = [tag, pushed, human_readable, tag_priority, is_semantic_tag, None]
+        newImageList.append(row)
+
+    # Sort in descending order of priority and timestamp
+    def sort_order(row):
+        return (row[3], row[0])
+    newImageList.sort(key=sort_order, reverse=True)
 
     if print_flag:
-        print(tabulate(sorted(imageList, key=itemgetter(0)), headers=['Image Name', 'Digest',
-                                           'Time Tagged']))
+        print(
+            tabulate(newImageList,
+                headers=['Image Name', 'Time Tagged', 'Relative', 'Priority', 'Is Semantic', 'Stable Version']
+            )
+        )
 
-    return imageList
+    return newImageList
 
 
 def get_state(container_name):

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -34,11 +34,12 @@ def echo_success(message):
 
 
 def human_readable_timediff(dt):
-    """ Generate a human readable time difference, Using 2 largest time intervals
-        ex: "1 hour 30 min"
+    """ Generate a human readable time difference, use the 2 largest time intervals
+    if the the first part is a one for example: "1 hour, 30 minutes ago", but
+    just use the largest time interval in other cases, for example: "18 hours ago"
 
-        :param dt: datetime we want to find the difference between current time
-        :type dt: datetime
+    :param dt: datetime we want to find the difference between current time
+    :type dt: datetime
     """
 
     attrs = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
@@ -46,7 +47,12 @@ def human_readable_timediff(dt):
         for attr in attrs if getattr(delta, attr)]
 
     parts = relativedelta(datetime.now(), dt)
-
     readable_parts = human_readable(parts)
-    readable_timediff = ', '.join(readable_parts[:2]) + ' ago'
+
+    # Show more detail when the first part is "1 day" or "1 hour"
+    if readable_parts and readable_parts[0].startswith('1 '):
+        readable_timediff = ', '.join(readable_parts[:2]) + ' ago'
+    else:
+        readable_timediff = ', '.join(readable_parts[:1]) + ' ago'
+
     return readable_timediff

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -2,7 +2,6 @@
 outputs.
 """
 from click import secho
-from dateutil.relativedelta import relativedelta
 from datetime import datetime
 from humanize import naturaltime
 

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -34,7 +34,12 @@ def echo_success(message):
 
 
 def human_readable_timediff(dt):
-    """ Generate a human readable time difference """
+    """ Generate a human readable time difference, Using 2 largest time intervals
+        ex: "1 hour 30 min"
+
+        :param dt: datetime we want to find the difference between current time
+        :type dt: datetime
+    """
 
     attrs = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
     human_readable = lambda delta: ['%d %s' % (getattr(delta, attr), getattr(delta, attr) > 1 and attr or attr[:-1]) 

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -2,6 +2,8 @@
 outputs.
 """
 from click import secho
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
 
 def echo_highlight(message):
@@ -29,3 +31,17 @@ def echo_success(message):
     :type message: str
     """
     return secho(message, fg='green', bold=True)
+
+
+def human_readable_timediff(dt):
+    """ Generate a human readable time difference """
+
+    attrs = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
+    human_readable = lambda delta: ['%d %s' % (getattr(delta, attr), getattr(delta, attr) > 1 and attr or attr[:-1]) 
+        for attr in attrs if getattr(delta, attr)]
+
+    parts = relativedelta(datetime.now(), dt)
+
+    readable_parts = human_readable(parts)
+    readable_timediff = ', '.join(readable_parts[:2]) + ' ago'
+    return readable_timediff

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -4,6 +4,7 @@ outputs.
 from click import secho
 from dateutil.relativedelta import relativedelta
 from datetime import datetime
+from humanize import naturaltime
 
 
 def echo_highlight(message):
@@ -41,18 +42,5 @@ def human_readable_timediff(dt):
     :param dt: datetime we want to find the difference between current time
     :type dt: datetime
     """
-
-    attrs = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
-    human_readable = lambda delta: ['%d %s' % (getattr(delta, attr), getattr(delta, attr) > 1 and attr or attr[:-1]) 
-        for attr in attrs if getattr(delta, attr)]
-
-    parts = relativedelta(datetime.now(), dt)
-    readable_parts = human_readable(parts)
-
-    # Show more detail when the first part is "1 day" or "1 hour"
-    if readable_parts and readable_parts[0].startswith('1 '):
-        readable_timediff = ', '.join(readable_parts[:2]) + ' ago'
-    else:
-        readable_timediff = ', '.join(readable_parts[:1]) + ' ago'
-
-    return readable_timediff
+    now = datetime.now()
+    return naturaltime(now - dt)

--- a/jbcli/jbcli/utils/format.py
+++ b/jbcli/jbcli/utils/format.py
@@ -35,12 +35,9 @@ def echo_success(message):
 
 
 def human_readable_timediff(dt):
-    """ Generate a human readable time difference, use the 2 largest time intervals
-    if the the first part is a one for example: "1 hour, 30 minutes ago", but
-    just use the largest time interval in other cases, for example: "18 hours ago"
+    """ Generate a human readable time difference between this time and now
 
     :param dt: datetime we want to find the difference between current time
     :type dt: datetime
     """
-    now = datetime.now()
-    return naturaltime(now - dt)
+    return naturaltime(datetime.now() - dt)

--- a/jbcli/jbcli/utils/storageutil.py
+++ b/jbcli/jbcli/utils/storageutil.py
@@ -23,10 +23,10 @@ class Stash(object):
         except IOError:
             return {}
 
-    def get(self, name):
+    def get(self, name, default=None):
         """Get a secret directly from the local file."""
         try:
-            return self.data.get(name)
+            return self.data.get(name, default)
         except IOError:
             pass
 

--- a/jbcli/requirements.in
+++ b/jbcli/requirements.in
@@ -11,3 +11,4 @@ elasticsearch~=6.3.1
 elasticsearch-dsl~=6.3.1
 tablib~=0.13.0
 PyInquirer~=1.0.3
+humanize~=0.5.1

--- a/jbcli/requirements.in
+++ b/jbcli/requirements.in
@@ -10,3 +10,4 @@ certifi~=2019.3.9
 elasticsearch~=6.3.1
 elasticsearch-dsl~=6.3.1
 tablib~=0.13.0
+PyInquirer~=1.0.3

--- a/jbcli/requirements.txt
+++ b/jbcli/requirements.txt
@@ -33,17 +33,22 @@ jsonschema==2.6.0         # via docker-compose
 odfpy==1.4.0              # via tablib
 openpyxl==2.6.3           # via tablib
 pathtools==0.1.2          # via watchdog
+prompt_toolkit==1.0.14    # via pyinquirer
+pygments==2.4.2           # via pyinquirer
+pyinquirer==1.0.3
 python-dateutil==2.8.0    # via botocore, elasticsearch-dsl
 pyyaml==3.13              # via docker-compose, tablib, watchdog
+regex==2019.8.19          # via pyinquirer
 requests==2.11.1          # via docker, docker-compose
 s3transfer==0.2.1         # via boto3
-six==1.12.0               # via docker, docker-compose, docker-pycreds, dockerpty, elasticsearch-dsl, python-dateutil, websocket-client
+six==1.12.0               # via docker, docker-compose, docker-pycreds, dockerpty, elasticsearch-dsl, prompt-toolkit, python-dateutil, websocket-client
 tablib==0.13.0
 tabulate==0.8.3
 texttable==0.8.8          # via docker-compose
 toml==0.10.0
 urllib3==1.24.3           # via botocore, elasticsearch
 watchdog==0.8.3
+wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.56.0  # via docker, docker-compose
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib

--- a/jbcli/requirements.txt
+++ b/jbcli/requirements.txt
@@ -26,6 +26,7 @@ enum34==1.1.6             # via docker-compose
 et-xmlfile==1.0.1         # via openpyxl
 functools32==3.2.3.post2  # via jsonschema
 futures==3.3.0            # via s3transfer
+humanize==0.5.1
 ipaddress==1.0.22         # via docker, docker-compose, elasticsearch-dsl
 jdcal==1.4.1              # via openpyxl
 jmespath==0.9.4           # via boto3, botocore


### PR DESCRIPTION
Ticket: [JB-1722 ](https://juiceanalytics.atlassian.net/browse/JB-1722 )
Type: Feature

#### This PR introduces the following changes

- all new right now
- adds the functionality `jb freshstart` which might become `jb start` later

## Documentation

This makes it so as long as the jb cli is available to you, you can run `jb freshstart` from any path and it will provide a list of options for different environments that are available to start devlandia in, with information about the image that those environments are based off of.

<img width="902" alt="Screen Shot 2019-09-17 at 2 41 22 PM" src="https://user-images.githubusercontent.com/35914606/65074170-e2afce80-d959-11e9-8086-be4d11352d29.png">


## dockerutil.image_list changes

Returns a priority sorted list of lists that contain:

- tag
- pushed (datetime)
- human readable pushed date
- tag priority (used for sorting, higher numbers are more important tags)
- is_semantic_tag (is the tag like 3.38.0)
- stable_version (if tag is stable, what semantic version is it based off of)

The list is sorted by priority and date. 

## `jb select` changes

- jb select runs from devlandia root
- it gets an environment and then a desired tag and sets that in a stashed dictionary. 
- the tag selection is based on the last 30 days. The --showall flag shows all tagged images.

```
 (devlandia) ~/dev/py/devlandia   feature/OPS-1722-env-choice-to-jb-start ●  jb select
? What environment would you like to change?  (Use arrow keys)
 ❯ test
   core
   hstm-test
   hstm-core

? What tag would you like to use in test?  (Use arrow keys)
 ❯ stable (published 11 days ago)
   ---------------
   develop (published 4 days ago)
   ---------------
   3.38.3 (published 11 days ago)
   3.38.2 (published 11 days ago)
   3.38.1 (published 13 days ago)
   3.38.0 (published 19 days ago)
   3.37.2 (published 27 days ago)
   3.37.1 (published 28 days ago)
   ---------------
   test-responsive-tests (published 20 days ago)
   test-python3-requirements (published 11 days ago)
   test-improvement_remove-threadlocal-context (published 14 days ago)
   test-improvement_JB-2540-better-adapting (published 13 days ago)
   test-improvement_JB-2537-jbo-editor-misc (published 17 days ago)
...
```

## `jb freshstart` 

This is a new `jb start` that runs from devlandia root. This merges info from `jb select` to give users a better idea of the code that will run in each environment

```
 (devlandia) ~/dev/py/devlandia   feature/OPS-1722-env-choice-to-jb-start ●  jb freshstart
Checking to see if Juicebox is running...
Welcome to devlandia!
Gathering data on available environments...

? what environment would you like to start?  (Use arrow keys)
 ❯ stable/master - (3.38.3) published 11 days ago
   dev - (develop) published 4 days ago
   core - (develop, set with `jb select`) published 4 days ago
   test - (develop, set with `jb select`) published 4 days ago
   hstm-stable
   hstm-dev
   hstm-core
   hstm-test - (3.38.2, set with `jb select`) published 11 days ago
```
