### PR TITLE
Fix environment image names

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:dev"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop"
     command: bash -c "/venv/bin/pip install -U -q -r requirements.txt && /venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"

--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:dev"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"

--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:stable"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:master"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   juicebox:
-    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:stable"
+    image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:master"
     command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"


### PR DESCRIPTION
Ticket: N/A
Type: Fix

#### This PR introduces the following changes

- Jenkins docker builds would tag the develop branch with dev, and master as stable, but we’re not doing that in codebuild now, it just tags it as the branch name.
- I pulled the stable image and made a new tag for master, so that change should be transparent for the stable and default value for the test environment, and nothing should need updating since their hashes match.
- The tags that dev and core were out of date by a few days, so this change will cause a new image to be pulled the next time it's started.

Nothing for the HSTM images should be effected right now.