### PR TITLE
[OPS-1723] use fruition.settings.contained for the django settings module of devlandia

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - JB_DB_HOST=postgres
       - JB_REDIS_LOCATION=redis:6379
       - DJANGO_DEBUG=on
+      - JB_INSECURE_COOKIES=yes
 
       - JB_DEVLANDIA=on
       - JB_LOGS_STDOUT=off

--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - DJANGO_DEBUG=on
 
       - JB_DEVLANDIA=on
+      - JB_LOGS_STDOUT=off
       - JB_DEBUG_LOGGING=on
       - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
       - JB_ADDITIONAL_ALLOWED_HOSTS=*

--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop"
-    command: bash -c "/venv/bin/pip install -U -q -r requirements.txt && /venv/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -U -q -r requirements.txt -r requirements_dev.txt && /venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"
@@ -20,16 +20,30 @@ services:
       - redis
     environment:
       - ENVIRONMENT=docker
-      - DJANGO_SETTINGS_MODULE=fruition.settings.docker
+      - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+
+      - JB_DB_NAME=juicebox
+      - JB_DB_USERNAME=juicebox
+      - JB_DB_PASSWORD=juicebox
+      - JB_DB_HOST=postgres
+      - JB_REDIS_LOCATION=redis:6379
+      - DJANGO_DEBUG=on
+
+      - JB_DEVLANDIA=on
+      - JB_DEBUG_LOGGING=on
+      - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
+      - JB_ADDITIONAL_ALLOWED_HOSTS=*
+
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_SECRET_ACCESS_KEY
       - AWS_ACCESS_KEY_ID
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
-      - JB_GOOGLE_CLOUD_PRIVKEY
+      - JB_GCLOUD_PRIVKEY
       - JB_GITHUB_FETCHAPP_CREDS
+      - JB_REDSHIFT_CONNECTION
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -412,15 +412,6 @@ def start(ctx, noupdate, noupgrade):
         echo_warning('An instance of Juicebox is already running')
 
 
-def _get_paramstore_secret(env, envkey, key, warning_message):
-    """Try to fetch a secret from paramstore and save it in env.
-    Show the warning message if the secret is not available."""
-    try:
-        env[envkey] = get_paramstore(key)
-    except botocore.exceptions.ClientError:
-        echo_warning(warning_message)
-
-
 def populate_env_with_secrets():
     env = os.environ.copy()
     env.update(get_deployment_secrets())

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -16,7 +16,7 @@ from PyInquirer import prompt, Separator
 from ..utils import apps, dockerutil, jbapiutil, subprocess
 from ..utils.format import echo_highlight, echo_warning, echo_success, human_readable_timediff
 from ..utils.juice_log_searcher import JuiceboxLoggingSearcher
-from ..utils.secrets import get_paramstore
+from ..utils.secrets import get_deployment_secrets
 from ..utils.reload import create_browser_instance
 from ..utils.storageutil import stash
 
@@ -423,15 +423,7 @@ def _get_paramstore_secret(env, envkey, key, warning_message):
 
 def populate_env_with_secrets():
     env = os.environ.copy()
-    _get_paramstore_secret(env,
-                           'JB_GOOGLE_CLOUD_PRIVKEY',
-                           'jbo-google-cloud-privkey',
-                           'These credentials do not have access to bigquery')
-    _get_paramstore_secret(env,
-                           'JB_GITHUB_FETCHAPP_CREDS',
-                           'opslord-github-credentials',
-                           'These credentials do not have access to '
-                           'fetch apps on github.')
+    env.update(get_deployment_secrets())
     return env
 
 

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -1018,7 +1018,6 @@ class TestDocker(object):
         dockerutil_mock.ensure_home.return_value = True
         runner = CliRunner()
         result = runner.invoke(cli, ['start', '--noupgrade'])
-        print(result)
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
             call.ensure_home(),

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -13,7 +13,7 @@ from ..cli.jb import cli
 from ..utils.dockerutil import WatchHandler
 
 
-@patch('jbcli.cli.jb.get_paramstore', new=lambda x: "FAKE_SECRET")
+@patch('jbcli.cli.jb.get_deployment_secrets', new=lambda: {})
 class TestDocker(object):
     def test_base(self):
         runner = CliRunner()
@@ -1018,6 +1018,7 @@ class TestDocker(object):
         dockerutil_mock.ensure_home.return_value = True
         runner = CliRunner()
         result = runner.invoke(cli, ['start', '--noupgrade'])
+        print(result)
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
             call.ensure_home(),

--- a/jbcli/jbcli/utils/secrets.py
+++ b/jbcli/jbcli/utils/secrets.py
@@ -13,6 +13,7 @@ def get_all_from_path(path):
 
     this returns {'FOO': 'a', 'BAR': 'b'}
     """
+    ssm = boto3.client('ssm')
     try:
         result = ssm.get_parameters_by_path(
             Path=path,
@@ -29,7 +30,6 @@ def get_all_from_path(path):
 
 
 def get_deployment_secrets():
-    ssm = boto3.client('ssm')
     env = get_all_from_path('/jb-deployment-vars/common/')
     env.update(get_all_from_path('/jb-deployment-vars/devlandia/'))
     return env

--- a/jbcli/jbcli/utils/secrets.py
+++ b/jbcli/jbcli/utils/secrets.py
@@ -1,9 +1,16 @@
 from __future__ import print_function
 
 import boto3
+import six
 
 
-def get_paramstore(param_name):
+def get_deployment_secrets():
     ssm = boto3.client('ssm')
-    parameter = ssm.get_parameter(Name=param_name, WithDecryption=True)
-    return parameter['Parameter']['Value'].encode('ascii')
+    result = ssm.get_parameters_by_path(
+        Path='/jb-deployment-vars/',
+        Recursive=True, WithDecryption=True,
+    )
+    # These ENCODE calls need to change for python 3 support
+    env = {param['Name'][len('/jb-deployment-vars/'):].encode('ascii'): param['Value'].encode('ascii') for param in result['Parameters']}
+    return env
+

--- a/jbcli/jbcli/utils/secrets.py
+++ b/jbcli/jbcli/utils/secrets.py
@@ -3,14 +3,34 @@ from __future__ import print_function
 import boto3
 import six
 
+def get_all_from_path(path):
+    """
+    Given a SSM parameter path, get all parameters stored recursively under that path.
+
+    Given `/PATH`, and parameters such as:
+
+        /PATH/FOO = a, /PATH/BAR = b
+
+    this returns {'FOO': 'a', 'BAR': 'b'}
+    """
+    try:
+        result = ssm.get_parameters_by_path(
+            Path=path,
+            Recursive=True, WithDecryption=True,
+        )
+    except Exception as e:
+        print("[WARNING] couldn't fetch parameters under path", path, e)
+        return {}
+    # These ENCODE calls probably need to change for python 3 support
+    return {
+        param['Name'].rsplit('/', 1)[-1].encode('ascii'): param['Value'].encode('ascii')
+        for param in result['Parameters']
+    }
+
 
 def get_deployment_secrets():
     ssm = boto3.client('ssm')
-    result = ssm.get_parameters_by_path(
-        Path='/jb-deployment-vars/',
-        Recursive=True, WithDecryption=True,
-    )
-    # These ENCODE calls need to change for python 3 support
-    env = {param['Name'][len('/jb-deployment-vars/'):].encode('ascii'): param['Value'].encode('ascii') for param in result['Parameters']}
+    env = get_all_from_path('/jb-deployment-vars/common/')
+    env.update(get_all_from_path('/jb-deployment-vars/devlandia/'))
     return env
 


### PR DESCRIPTION
Ticket: [OPS-1723](https://juiceanalytics.atlassian.net/browse/OPS-1723)

This relies on https://github.com/juiceinc/fruition/pull/1678

## Changes

- Change DSM to fruition.settings.contained
- pass in environment variables to configure it
- change the way secrets are fetched to be more consistent and discoverable
- also upgrade requirements_dev.txt in the core environment

