### PR TITLE
[OPS-1756] fail gracefully when unable to fetch ssm secrets

### DIFF
--- a/environments/core/fruition
+++ b/environments/core/fruition
@@ -1,1 +1,0 @@
-/Users/david.paul/Desktop/fruition

--- a/environments/core/fruition
+++ b/environments/core/fruition
@@ -1,0 +1,1 @@
+/Users/david.paul/Desktop/fruition

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -412,11 +412,26 @@ def start(ctx, noupdate, noupgrade):
         echo_warning('An instance of Juicebox is already running')
 
 
+def _get_paramstore_secret(env, envkey, key, warning_message):
+    """Try to fetch a secret from paramstore and save it in env.
+    Show the warning message if the secret is not available."""
+    try:
+        env[envkey] = get_paramstore(key)
+    except ClientError:
+        echo_warning(warning_message)
+
+
 def populate_env_with_secrets():
     env = os.environ.copy()
-    env['JB_GOOGLE_CLOUD_PRIVKEY'] = get_paramstore('jbo-google-cloud-privkey')
-    env['JB_GITHUB_FETCHAPP_CREDS'] = get_paramstore(
-        'opslord-github-credentials')
+    _get_paramstore_secret(env,
+                           'JB_GOOGLE_CLOUD_PRIVKEY',
+                           'jbo-google-cloud-privkey',
+                           'These credentials do not have access to bigquery')
+    _get_paramstore_secret(env,
+                           'JB_GITHUB_FETCHAPP_CREDS',
+                           'opslord-github-credentials',
+                           'These credentials do not have access to '
+                           'fetch apps on github.')
     return env
 
 

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -417,7 +417,7 @@ def _get_paramstore_secret(env, envkey, key, warning_message):
     Show the warning message if the secret is not available."""
     try:
         env[envkey] = get_paramstore(key)
-    except ClientError:
+    except botocore.exceptions.ClientError:
         echo_warning(warning_message)
 
 


### PR DESCRIPTION
Ticket: [OPS-1756](https://juiceanalytics.atlassian.net/browse/OPS-1756)
Type: Fix/Pop up

#### This PR introduces the following changes

- added functionality to fail gracefully when secrets cant be fetched from  ssm parameter store

## Documentation
not sure if this is 100% ready, still getting errors, there's a problem with the role when i run from hstm giving me access denied that it won pass over, when ran in legacy it fails because controlcenter credentials are not stored in the legacy credstash. 
