### PR TITLE
[OPS-1723] update the other fruition environments to work with the latest `fruition.settings.contained` DSM

### DIFF
--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -19,14 +19,32 @@ services:
       - redis
     environment:
       - ENVIRONMENT=docker
-      - DJANGO_SETTINGS_MODULE=fruition.settings.docker
+      - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+
+      - JB_DB_NAME=juicebox
+      - JB_DB_USERNAME=juicebox
+      - JB_DB_PASSWORD=juicebox
+      - JB_DB_HOST=postgres
+      - JB_REDIS_LOCATION=redis:6379
+      - DJANGO_DEBUG=on
+      - JB_INSECURE_COOKIES=yes
+
+      - JB_DEVLANDIA=on
+      - JB_LOGS_STDOUT=off
+      - JB_DEBUG_LOGGING=on
+      - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
+      - JB_ADDITIONAL_ALLOWED_HOSTS=*
+
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_SECRET_ACCESS_KEY
       - AWS_ACCESS_KEY_ID
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
+      - JB_GCLOUD_PRIVKEY
+      - JB_GITHUB_FETCHAPP_CREDS
+      - JB_REDSHIFT_CONNECTION
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/py3/docker-compose.yml
+++ b/environments/py3/docker-compose.yml
@@ -19,16 +19,32 @@ services:
       - redis
     environment:
       - ENVIRONMENT=docker
-      - DJANGO_SETTINGS_MODULE=fruition.settings.docker
+      - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+
+      - JB_DB_NAME=juicebox
+      - JB_DB_USERNAME=juicebox
+      - JB_DB_PASSWORD=juicebox
+      - JB_DB_HOST=postgres
+      - JB_REDIS_LOCATION=redis:6379
+      - DJANGO_DEBUG=on
+      - JB_INSECURE_COOKIES=yes
+
+      - JB_DEVLANDIA=on
+      - JB_LOGS_STDOUT=off
+      - JB_DEBUG_LOGGING=on
+      - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
+      - JB_ADDITIONAL_ALLOWED_HOSTS=*
+
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_SECRET_ACCESS_KEY
       - AWS_ACCESS_KEY_ID
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
-      - JB_GOOGLE_CLOUD_PRIVKEY
+      - JB_GCLOUD_PRIVKEY
       - JB_GITHUB_FETCHAPP_CREDS
+      - JB_REDSHIFT_CONNECTION
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/stable/docker-compose.yml
+++ b/environments/stable/docker-compose.yml
@@ -19,14 +19,32 @@ services:
       - redis
     environment:
       - ENVIRONMENT=docker
-      - DJANGO_SETTINGS_MODULE=fruition.settings.docker
+      - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+
+      - JB_DB_NAME=juicebox
+      - JB_DB_USERNAME=juicebox
+      - JB_DB_PASSWORD=juicebox
+      - JB_DB_HOST=postgres
+      - JB_REDIS_LOCATION=redis:6379
+      - DJANGO_DEBUG=on
+      - JB_INSECURE_COOKIES=yes
+
+      - JB_DEVLANDIA=on
+      - JB_LOGS_STDOUT=off
+      - JB_DEBUG_LOGGING=on
+      - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
+      - JB_ADDITIONAL_ALLOWED_HOSTS=*
+
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_SECRET_ACCESS_KEY
       - AWS_ACCESS_KEY_ID
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
+      - JB_GCLOUD_PRIVKEY
+      - JB_GITHUB_FETCHAPP_CREDS
+      - JB_REDSHIFT_CONNECTION
   postgres:
     environment:
       - POSTGRES_USER=juicebox

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -19,14 +19,32 @@ services:
       - redis
     environment:
       - ENVIRONMENT=docker
-      - DJANGO_SETTINGS_MODULE=fruition.settings.docker
+      - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+
+      - JB_DB_NAME=juicebox
+      - JB_DB_USERNAME=juicebox
+      - JB_DB_PASSWORD=juicebox
+      - JB_DB_HOST=postgres
+      - JB_REDIS_LOCATION=redis:6379
+      - DJANGO_DEBUG=on
+      - JB_INSECURE_COOKIES=yes
+
+      - JB_DEVLANDIA=on
+      - JB_LOGS_STDOUT=off
+      - JB_DEBUG_LOGGING=on
+      - JB_APPADMIN_SERVICE=https://manage-dev.juiceboxdata.com
+      - JB_ADDITIONAL_ALLOWED_HOSTS=*
+
       - APP_ID=1ec756a5-e04a-4885-87ad-3325bbdd4872
       - AWS_SECRET_ACCESS_KEY
       - AWS_ACCESS_KEY_ID
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
+      - JB_GCLOUD_PRIVKEY
+      - JB_GITHUB_FETCHAPP_CREDS
+      - JB_REDSHIFT_CONNECTION
   postgres:
     environment:
       - POSTGRES_USER=juicebox


### PR DESCRIPTION
Ticket: [OPS-1723](https://juiceanalytics.atlassian.net/browse/OPS-1723)

## Changes

copy the docker-compose.yml changes from `core` to all of the other fruition environments.

This is going to be a bit awkward if anyone `jb select`s an older release...