### PR TITLE
[FIX] jbapiutil log echoing when there is unicode in the log messages

### DIFF
--- a/jbcli/jbcli/utils/jbapiutil.py
+++ b/jbcli/jbcli/utils/jbapiutil.py
@@ -51,9 +51,9 @@ def echo_result(result):
     for log in logs:
         level = log.pop('level', 'unknown')
         event = log.pop('event', 'unknown')
-        content = '{:10s}{}\n\n'.format('[' + level + ']', event)
+        content = u'{:10s}{}\n\n'.format('[' + level + ']', event)
         for k in sorted(log.keys()):
-            content += '{:>20}: {}\n'.format(k, log[k])
+            content += u'{:>20}: {}\n'.format(k, log[k])
         if level in ('error', 'warning'):
             echo_warning(content)
         else:


### PR DESCRIPTION
Ticket: N/A quick fix

## Changes

When the logs returned by load_juicebox_app contained non-ASCII text, jbcli would blow up because it was trying to encode them into bytes w/ the ASCII encoding.

By using unicode strings here (this is forward-compatible to python 3), we keep the strings in unicode format instead of trying to cast them to str/bytes.