### PR TITLE
Allow `jb manage` to be run without JB running in the background

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -727,7 +727,8 @@ def pull(tag=None):
 @click.option('--runtime', default='venv', help='Which runtime to use, defaults to venv, the only other option is venv3')
 def manage(args, runtime):
     """Allows you to run arbitrary management commands."""
-    dockerutil.run_jb(['/{}/bin/python'.format(runtime), 'manage.py'] + list(args))
+    cmd = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
+    dockerutil.run_jb(cmd, env=populate_env_with_secrets())
 
 
 @cli.command()

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -731,6 +731,7 @@ def manage(args, runtime, env):
     cmd = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
     if env is not None:
         os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
+    dockerutil.pull(None)
     try:
         dockerutil.run_jb(cmd, env=populate_env_with_secrets())
     except subprocess.CalledProcessError as e:

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -608,7 +608,7 @@ def freshstart(ctx, env, noupdate, noupgrade, ssh):
             subprocess.check_call(
                 ['killall', '-HUP' 'com.docker.hyperkit'])
             time.sleep(30)
-            start(noupdate=noupdate, ssh=ssh)
+            freshstart(env, noupdate=noupdate, noupgrade=noupgrade, ssh=ssh)
         else:
             raise
 
@@ -727,17 +727,7 @@ def pull(tag=None):
 @click.option('--runtime', default='venv', help='Which runtime to use, defaults to venv, the only other option is venv3')
 def manage(args, runtime):
     """Allows you to run arbitrary management commands."""
-    try:
-        if dockerutil.is_running():
-            cmdline = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
-            click.echo('Invoking inside container: %s' % ' '.join(cmdline))
-            dockerutil.run(join(cmdline))
-        else:
-            echo_warning('Juicebox not running.  Run jb start')
-            click.get_current_context().abort()
-    except docker.errors.APIError:
-        echo_warning('Could not clear cache')
-        click.get_current_context().abort()
+    dockerutil.run_jb(['/{}/bin/python'.format(runtime), 'manage.py'] + list(args))
 
 
 @cli.command()

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -743,7 +743,9 @@ def manage(args, env):
             os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
             dockerutil.run_jb(cmd, env=populate_env_with_secrets())
         else:
-            echo_warning("please pass --env, or start juicebox in the background first")
+            echo_warning(
+                "Juicebox not running and no --env given. "
+                "Please pass --env, or start juicebox in the background first.")
             click.get_current_context().abort()
     except subprocess.CalledProcessError as e:
         echo_warning("manage.py exited with {}".format(e.returncode))

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -725,9 +725,12 @@ def pull(tag=None):
 ))
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.option('--runtime', default='venv', help='Which runtime to use, defaults to venv, the only other option is venv3')
-def manage(args, runtime):
+@click.option('--env', help='Which environment to use')
+def manage(args, runtime, env):
     """Allows you to run arbitrary management commands."""
     cmd = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
+    if env is not None:
+        os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
     try:
         dockerutil.run_jb(cmd, env=populate_env_with_secrets())
     except subprocess.CalledProcessError as e:

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -728,7 +728,11 @@ def pull(tag=None):
 def manage(args, runtime):
     """Allows you to run arbitrary management commands."""
     cmd = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
-    dockerutil.run_jb(cmd, env=populate_env_with_secrets())
+    try:
+        dockerutil.run_jb(cmd, env=populate_env_with_secrets())
+    except subprocess.CalledProcessError as e:
+        echo_warning("manage.py exited with {}".format(e.returncode))
+        click.get_current_context().abort()
 
 
 @cli.command()

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -731,7 +731,6 @@ def manage(args, runtime, env):
     cmd = ['/{}/bin/python'.format(runtime), 'manage.py'] + list(args)
     if env is not None:
         os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
-    dockerutil.pull(None)
     try:
         dockerutil.run_jb(cmd, env=populate_env_with_secrets())
     except subprocess.CalledProcessError as e:

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -39,7 +39,7 @@ class WatchHandler(FileSystemEventHandler):
         else:
             path = event.src_path.split('/')
 
-        # Path looks like 
+        # Path looks like
         # ['..', '..', 'apps', 'privileging', 'stacks', 'overview', 'templates.html']
         app = path[3]
         filename = path[-1]
@@ -61,7 +61,7 @@ class WatchHandler(FileSystemEventHandler):
                 if self.should_reload:
                     refresh_browser()
 
-        else:            
+        else:
             click.echo('Change to {} ignored'.format(event.src_path))
 
         click.echo('Waiting for changes...')
@@ -71,10 +71,10 @@ def _intersperse(el, l):
     return [y for x in zip([el]*len(l), l) for y in x]
 
 
-def docker_compose(arg, env=None):
+def docker_compose(args, env=None):
     file_args = _intersperse('-f', glob('docker-compose-*.yml'))
     cmd = (
-        ['docker-compose', '-f', 'docker-compose.yml'] + file_args + [arg]
+        ['docker-compose', '-f', 'docker-compose.yml'] + file_args + args
     )
     return check_call(cmd, env=env)
 
@@ -82,17 +82,21 @@ def docker_compose(arg, env=None):
 def up(env=None):
     """Starts and optionally creates a Docker environment based on
     docker-compose.yml """
-    docker_compose('up', env=env)
+    docker_compose(['up'], env=env)
+
+
+def run_jb(cmd, env=None):
+    docker_compose(['run', 'juicebox'] + cmd, env=env)
 
 
 def destroy():
     """Removes all containers and networks defined in docker-compose.yml"""
-    docker_compose('down')
+    docker_compose(['down'])
 
 
 def halt():
     """Halts all containers defined in docker-compose file."""
-    docker_compose('stop')
+    docker_compose(['stop'])
 
 
 def is_running():
@@ -235,7 +239,7 @@ def image_list(showall=False, print_flag=True, semantic=False):
                 is_semantic_tag = bool(semantic_version_tag_pattern.match(tag))
                 if tag == 'master':
                     tag_priority = 4
-                elif tag == 'develop': 
+                elif tag == 'develop':
                     tag_priority = 3
                 elif is_semantic_tag:
                     tag_priority = 2

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -104,16 +104,11 @@ def is_running():
 
     :rtype: ``bool``
     """
-    running = False
     click.echo('Checking to see if Juicebox is running...')
-    containers = client.containers.list(all=True)
-    if containers:
-        for container in containers:
-
-            if 'juicebox' in container.name and get_state(
-                    container.name) == 'running':
-                running = True
-    return running
+    containers = client.containers.list()
+    for container in containers:
+        if 'juicebox' in container.name:
+            return container
 
 
 def ensure_root():
@@ -146,13 +141,18 @@ def ensure_home():
 
     :rtype: ``bool``
     """
-    if not os.path.isfile('docker-compose.yml') or not os.path.isdir('../../apps'):
+    if check_home() is None:
         # We're not in the environment home
         echo_warning(
             'Please run this command from inside the desired environment in '
             'Devlandia.')
         click.get_current_context().abort()
     return True
+
+
+def check_home():
+    if os.path.isfile('docker-compose.yml') and os.path.isdir('../../apps'):
+        return os.path.dirname(os.path.abspath(os.path.curdir))
 
 
 def run(command):


### PR DESCRIPTION
Ticket: N/A

## Changes

- change `jb manage` so that it can spin up containers if jb isn't already running in the background.
  - a new `--env` parameter is added so you can select which environment to run in.
  - The current directory is also honored if you happen to be inside of an environment directory.

## Documentation

`jb manage` now tries its best to run your management command no matter what. You can give it an `--env` parameter to tell it which environment to run the manage command in.

I often want to run unit tests with `jb manage test`, but don't want to bother with running a full devlandia jb in the background. This can be especially frustrating if my code is currently broken in a way that would prevent JB from starting up, which means I need to fix it enough to get `jb start` to work, and _then_ be able to run jb manage.

So now, I can run `jb manage --env core test` to run my unit tests regardless of whether JB is running or not. If it is running, it will run the command in the existing container. If it isn't, it'll use docker-compose to start up a fresh one just for the lifetime of the command (which is very quick, because it's not running the full startup scripts).

Backwards-compatibility is maintained because if you don't pass `--env` (or aren't in an environment directory), we will still look up a JB container and run the command in it.