### PR TITLE
get rid of /venv3 usage in docker-compose files

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv3/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv3/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"

--- a/environments/dev/docker-compose.yml
+++ b/environments/dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv3/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"

--- a/environments/hstm-newcore/docker-compose.yml
+++ b/environments/hstm-newcore/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv3/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv3/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"

--- a/environments/py3/docker-compose.yml
+++ b/environments/py3/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv3/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"

--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:master-py3"
-    command: bash -c "/venv3/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/python docker/entrypoint.py"
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"


### PR DESCRIPTION
Ticket: N/A

## Changes

- change all mentions of `/venv3` to `/venv` in `docker-compose.yml` files

`/venv3` has been aliased to `/venv` for a while now so this should be a non-breaking change, and the unified Dockerfile that I wrote for fruition no longer creates a `/venv3`.

