### PR TITLE
[OPS-1746] rename freshstart to start

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -382,6 +382,12 @@ def select(tag, env=None, showall=False):
         dockerutil.set_tag(env, tag)
 
 
+def populate_env_with_secrets():
+    env = get_deployment_secrets()
+    env.update(os.environ)
+    return env
+
+
 def cleanup_ssh(env):
     compose_fn = os.path.join(DEVLANDIA_DIR, 'environments', env, 'docker-compose-ssh.yml')
     try:
@@ -689,7 +695,7 @@ def manage(args, env):
         elif env is not None:
             click.echo("starting new {}".format(env))
             os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
-            dockerutil.run_jb(cmd)
+            dockerutil.run_jb(cmd, env=populate_env_with_secrets())
         else:
             echo_warning(
                 "Juicebox not running and no --env given. "

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -14,7 +14,6 @@ import time
 from multiprocessing import Process
 from subprocess import Popen
 
-import botocore.exceptions
 import click
 import docker.errors
 from PyInquirer import prompt, Separator
@@ -471,8 +470,12 @@ def start(ctx, env, noupdate, noupgrade, ssh):
         echo_warning('Run `jb stop` to stop this instance.')
         return
 
-    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-    os.chdir(repo_root)
+    if env is None:
+        # If we're already in an environment directory, use it
+        abs_cwd = os.path.abspath('.')
+        if os.path.basename(os.path.dirname(abs_cwd)) == 'environments':
+            env = os.path.basename(abs_cwd)
+    os.chdir(DEVLANDIA_DIR)
     if env is None:
         env = get_environment_interactively()
 

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -503,9 +503,10 @@ def start(ctx, env, noupdate, noupgrade, ssh):
     if env.startswith('hstm-new'):
         activate_hstm()
     cleanup_ssh(env)
+    environ = populate_env_with_secrets()
     if ssh:
-        activate_ssh(env, get_deployment_secrets())
-    dockerutil.up()
+        activate_ssh(env, environ)
+    dockerutil.up(env=environ)
 
 
 def get_environment_interactively():

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -89,7 +89,7 @@ def package(applications, bucket, runtime):
 @click.option('--app', help='The app to upload data to', required=True)
 @click.option('--runtime', default='venv', help='Which runtime to use, defaults to venv, the only other option is venv3')
 def upload(datafile, app, runtime):
-    """Upload data to a juicebox app 
+    """Upload data to a juicebox app
     """
     if dockerutil.is_running() and dockerutil.ensure_home():
         failed_apps = []
@@ -475,6 +475,7 @@ def start(ctx, env, noupdate, noupgrade, ssh):
         abs_cwd = os.path.abspath('.')
         if os.path.basename(os.path.dirname(abs_cwd)) == 'environments':
             env = os.path.basename(abs_cwd)
+
     os.chdir(DEVLANDIA_DIR)
     if env is None:
         env = get_environment_interactively()

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -1013,57 +1013,6 @@ class TestCli(object):
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
-    def test_start(self, dockerutil_mock):
-        dockerutil_mock.is_running.return_value = False
-        dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['start', '--noupgrade'])
-        assert result.exit_code == 0
-        assert dockerutil_mock.mock_calls == [
-            call.is_running(),
-            call.pull(tag=None),
-            call.up(env=ANY)
-        ]
-
-    @patch('jbcli.cli.jb.dockerutil')
-    def test_start_noupgrade(self, dockerutil_mock):
-        dockerutil_mock.is_running.return_value = False
-        dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['start', '--noupgrade'])
-        assert result.exit_code == 0
-        assert dockerutil_mock.mock_calls == [
-            call.is_running(),
-            call.pull(tag=None),
-            call.up(env=ANY)
-        ]
-
-    @patch('jbcli.cli.jb.dockerutil')
-    def test_start_noupdate(self, dockerutil_mock):
-        dockerutil_mock.is_running.return_value = False
-        dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['start', '--noupdate', '--noupgrade'])
-        assert dockerutil_mock.mock_calls == [
-            call.is_running(),
-            call.up(env=ANY)
-        ]
-        assert result.exit_code == 0
-
-    @patch('jbcli.cli.jb.dockerutil')
-    def test_start_already_running(self, dockerutil_mock):
-        dockerutil_mock.is_running.return_value = True
-        dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['start', '--noupgrade'])
-
-        assert 'An instance of Juicebox is already running' in result.output
-        assert result.exit_code == 0
-        assert dockerutil_mock.mock_calls == [
-            call.is_running()
-        ]
-
-    @patch('jbcli.cli.jb.dockerutil')
     @patch('jbcli.cli.jb.apps')
     @patch('jbcli.cli.jb.os')
     def test_clone(self, os_mock, apps_mock, dockerutil_mock):

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -361,7 +361,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3'])
 
         assert 'App cookies already exists.' in result.output
         assert result.exit_code == 0
@@ -1253,7 +1253,7 @@ class TestCli(object):
         os_mock.environ.return_value = False
         os_mock.path.join.return_value = ''
         os_mock.getcwd.return_value = ''
-        os_mock.path.exists.return_value = False
+        os_mock.path.exists.return_value = True
         os_mock.symlink.return_value = False
 
         result = invoke(['yo_upgrade'])

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -1,14 +1,17 @@
 from __future__ import print_function
 
-from subprocess import CalledProcessError
 from collections import namedtuple
+import os
+from subprocess import CalledProcessError
 
 from click.testing import CliRunner
 from docker.errors import APIError
 from mock import call, patch, ANY
 
-from ..cli.jb import cli
+from ..cli.jb import DEVLANDIA_DIR, cli
 
+
+CORE_DIR = os.path.join(DEVLANDIA_DIR, 'environments/core')
 
 Container = namedtuple('Container', ['name'])
 
@@ -965,8 +968,9 @@ class TestCli(object):
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
-    def test_start(self, dockerutil_mock):
+    def test_start(self, dockerutil_mock, monkeypatch):
         """Starting brings docker-compose up in the environment of the cwd."""
+        monkeypatch.chdir(CORE_DIR)
         dockerutil_mock.is_running.return_value = False
         dockerutil_mock.ensure_home.return_value = True
         result = invoke(['start', '--noupgrade'], catch_exceptions=False)
@@ -978,7 +982,8 @@ class TestCli(object):
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
-    def test_start_noupgrade(self, dockerutil_mock):
+    def test_start_noupgrade(self, dockerutil_mock, monkeypatch):
+        monkeypatch.chdir(CORE_DIR)
         dockerutil_mock.is_running.return_value = False
         dockerutil_mock.ensure_home.return_value = True
         result = invoke(['start', '--noupgrade'])
@@ -990,7 +995,8 @@ class TestCli(object):
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
-    def test_start_noupdate(self, dockerutil_mock):
+    def test_start_noupdate(self, dockerutil_mock, monkeypatch):
+        monkeypatch.chdir(CORE_DIR)
         dockerutil_mock.is_running.return_value = False
         dockerutil_mock.ensure_home.return_value = True
         result = invoke(['start', '--noupdate', '--noupgrade'])

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -13,26 +13,26 @@ from ..cli.jb import cli
 Container = namedtuple('Container', ['name'])
 
 
+def invoke(*args, **kwargs):
+    kwargs['catch_exceptions'] = False
+    return CliRunner().invoke(cli, *args, **kwargs)
+
+
 @patch('jbcli.cli.jb.get_deployment_secrets', new=lambda: {'test_secret': 'true'})
 class TestCli(object):
     def test_base(self):
-        runner = CliRunner()
-        result = runner.invoke(cli)
-
+        result = invoke()
         assert 'Juicebox CLI app' in result.output
         assert result.exit_code == 0
 
     def test_bad_command(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ['cookies'])
-
+        result = invoke(['cookies'])
         assert result.exit_code == 2
         assert 'No such command "cookies"' in result.output
 
     @patch('jbcli.cli.jb.apps')
     def test_create_full(self, app_mock):
-        runner = CliRunner()
-        result = runner.invoke(cli, ['create', 'cookies'])
+        result = invoke(['create', 'cookies'])
         assert app_mock.mock_calls == []
         assert result.output == 'yo juicebox will take care of all your needs now.\n'
         assert result.exit_code == 0
@@ -41,8 +41,7 @@ class TestCli(object):
     def test_package_single(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies'])
+        result = invoke(['package', 'cookies'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -56,8 +55,7 @@ class TestCli(object):
     def test_package_single_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['package', 'cookies', '--runtime', 'venv3'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -71,8 +69,7 @@ class TestCli(object):
     def test_package_to_bucket(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', '--bucket', 'test_bucket'])
+        result = invoke(['package', 'cookies', '--bucket', 'test_bucket'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -86,9 +83,7 @@ class TestCli(object):
     def test_package_to_bucket_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', '--bucket',
-                                     'test_bucket', '--runtime', 'venv3'])
+        result = invoke(['package', 'cookies', '--bucket', 'test_bucket', '--runtime', 'venv3'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -102,8 +97,7 @@ class TestCli(object):
     @patch('jbcli.cli.jb.dockerutil')
     def test_package_not_running(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies'])
+        result = invoke(['package', 'cookies'])
         assert result.exit_code == 1
         assert dockerutil_mock.mock_calls == [
             call.is_running()
@@ -114,8 +108,7 @@ class TestCli(object):
     @patch('jbcli.cli.jb.dockerutil')
     def test_package_not_running_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['package', 'cookies', '--runtime', 'venv3'])
         assert result.exit_code == 1
         assert dockerutil_mock.mock_calls == [
             call.is_running()
@@ -127,8 +120,7 @@ class TestCli(object):
     def test_package_multiple(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', 'chocolate_chip'])
+        result = invoke(['package', 'cookies', 'chocolate_chip'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -144,8 +136,7 @@ class TestCli(object):
     def test_package_multiple_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['package', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
@@ -163,8 +154,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         dockerutil_mock.run.side_effect = APIError('Fail')
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies'])
+        result = invoke(['package', 'cookies'])
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.ensure_home(),
@@ -181,8 +171,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         dockerutil_mock.run.side_effect = APIError('Fail')
-        runner = CliRunner()
-        result = runner.invoke(cli, ['package', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['package', 'cookies', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.ensure_home(),
@@ -206,8 +195,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
@@ -235,8 +223,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = True
         apiutil_mock.get_admin_token.return_value = 'foo'
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
@@ -266,8 +253,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3'])
 
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
@@ -296,8 +282,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = True
         apiutil_mock.get_admin_token.return_value = 'foo'
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3' ])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3' ])
 
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
@@ -320,8 +305,7 @@ class TestCli(object):
         os_mock.path.isdir.return_value = False
         dockerutil_mock.is_running.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['upload', '--app=foo', 'cookies.csv'])
+        result = invoke(['upload', '--app=foo', 'cookies.csv'])
 
         assert 'Uploading...' in result.output
         assert result.exit_code == 0
@@ -338,8 +322,7 @@ class TestCli(object):
         os_mock.path.isdir.return_value = False
         dockerutil_mock.is_running.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['upload', '--app=foo', 'cookies.csv', '--runtime', 'venv3'])
+        result = invoke(['upload', '--app=foo', 'cookies.csv', '--runtime', 'venv3'])
 
         assert 'Uploading...' in result.output
         assert result.exit_code == 0
@@ -359,8 +342,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert 'App cookies already exists.' in result.output
         assert result.exit_code == 0
@@ -379,7 +361,6 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
         result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
 
         assert 'App cookies already exists.' in result.output
@@ -394,8 +375,7 @@ class TestCli(object):
     def test_add_not_running(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running()
@@ -407,8 +387,7 @@ class TestCli(object):
     def test_add_not_running_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3'])
 
         assert dockerutil_mock.mock_calls == [
             call.is_running()
@@ -428,8 +407,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--add-desktop'])
+        result = invoke(['add', 'cookies', '--add-desktop'])
 
         assert 'Adding cookies...' in result.output
         assert 'Downloading app cookies from Github.' in result.output
@@ -458,8 +436,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--add-desktop', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--add-desktop', '--runtime', 'venv3'])
 
         assert 'Adding cookies...' in result.output
         assert 'Downloading app cookies from Github.' in result.output
@@ -487,8 +464,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', 'chocolate_chip'])
+        result = invoke(['add', 'cookies', 'chocolate_chip'])
 
         assert 'Adding cookies...' in result.output
         assert 'Adding chocolate_chip'
@@ -524,8 +500,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert 'Adding cookies...' in result.output
         assert 'Adding chocolate_chip'
@@ -560,8 +535,7 @@ class TestCli(object):
         apps_mock.make_github_repo_url.return_value = 'git cookies'
         proc_mock.side_effect = CalledProcessError(2, 'cmd', 'Ugh Cake')
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert 'Adding cookies...' in result.output
         assert 'Failed to load: cookies.' in result.output
@@ -586,8 +560,7 @@ class TestCli(object):
         apps_mock.make_github_repo_url.return_value = 'git cookies'
         proc_mock.side_effect = CalledProcessError(2, 'cmd', 'Ugh Cake')
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3'])
 
         assert 'Adding cookies...' in result.output
         assert 'Failed to load: cookies.' in result.output
@@ -614,8 +587,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies'])
+        result = invoke(['add', 'cookies'])
 
         assert 'Adding cookies...' in result.output
         assert 'Downloading app cookies from Github.' in result.output
@@ -645,8 +617,7 @@ class TestCli(object):
         apiutil_mock.load_app.return_value = False
         apiutil_mock.get_admin_token.return_value = None
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--runtime', 'venv3'])
 
         assert 'Adding cookies...' in result.output
         assert 'Downloading app cookies from Github.' in result.output
@@ -678,8 +649,7 @@ class TestCli(object):
             True, CalledProcessError(2, 'cmd', 'Ugh Cake')
         ]
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--add-desktop'])
+        result = invoke(['add', 'cookies', '--add-desktop'])
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
@@ -713,8 +683,7 @@ class TestCli(object):
             True, CalledProcessError(2, 'cmd', 'Ugh Cake')
         ]
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['add', 'cookies', '--add-desktop', '--runtime', 'venv3'])
+        result = invoke(['add', 'cookies', '--add-desktop', '--runtime', 'venv3'])
         assert 'Adding cookies...' in result.output
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
@@ -739,8 +708,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes'])
+        result = invoke(['remove', 'cookies', '--yes'])
 
         assert 'Removing cookies...' in result.output
         assert 'Successfully deleted cookies' in result.output
@@ -761,8 +729,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes', '--runtime', 'venv3'])
+        result = invoke(['remove', 'cookies', '--yes', '--runtime', 'venv3'])
 
         assert 'Removing cookies...' in result.output
         assert 'Successfully deleted cookies' in result.output
@@ -779,8 +746,7 @@ class TestCli(object):
     def test_remove_not_running(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes'])
+        result = invoke(['remove', 'cookies', '--yes'])
 
         assert 'Juicebox is not running.  Run jb start.' in result.output
         assert result.exit_code == 1
@@ -793,8 +759,7 @@ class TestCli(object):
     def test_remove_not_running(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes', '--runtime', 'venv3'])
+        result = invoke(['remove', 'cookies', '--yes', '--runtime', 'venv3'])
 
         assert 'Juicebox is not running.  Run jb start.' in result.output
         assert result.exit_code == 1
@@ -808,8 +773,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes'])
+        result = invoke(['remove', 'cookies', '--yes'])
 
         assert 'Juicebox is not running.  Run jb start.' in result.output
         assert result.exit_code == 1
@@ -824,8 +788,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', '--yes', '--runtime', 'venv3'])
+        result = invoke(['remove', 'cookies', '--yes', '--runtime', 'venv3'])
 
         assert 'Juicebox is not running.  Run jb start.' in result.output
         assert result.exit_code == 1
@@ -843,8 +806,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', 'cake', '--yes'])
+        result = invoke(['remove', 'cookies', 'cake', '--yes'])
 
         assert 'Removing cookies...' in result.output
         assert 'Removing cake...' in result.output
@@ -874,8 +836,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['remove', 'cookies', 'cake', '--yes', '--runtime', 'venv3'])
+        result = invoke(['remove', 'cookies', 'cake', '--yes', '--runtime', 'venv3'])
 
         assert 'Removing cookies...' in result.output
         assert 'Removing cake...' in result.output
@@ -904,8 +865,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         time_mock.sleep.side_effect = KeyboardInterrupt
-        runner = CliRunner()
-        result = runner.invoke(cli, ['watch'])
+        result = invoke(['watch'])
 
         assert process_mock.mock_calls == [
             call(target=dockerutil_mock.jb_watch, kwargs={
@@ -923,8 +883,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         time_mock.sleep.side_effect = KeyboardInterrupt
-        runner = CliRunner()
-        result = runner.invoke(cli, ['watch', '--app', 'test'])
+        result = invoke(['watch', '--app', 'test'])
 
         assert process_mock.mock_calls == [
             call(target=dockerutil_mock.jb_watch, kwargs={
@@ -935,7 +894,6 @@ class TestCli(object):
 
         assert result.exit_code == 0
 
-
     @patch('jbcli.cli.jb.Process')
     @patch('jbcli.cli.jb.time')
     @patch('jbcli.cli.jb.dockerutil')
@@ -944,8 +902,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         time_mock.sleep.side_effect = KeyboardInterrupt
-        runner = CliRunner()
-        result = runner.invoke(cli, ['watch', '--reload'])
+        result = invoke(['watch', '--reload'])
         assert process_mock.mock_calls == [
             call(target=dockerutil_mock.jb_watch, kwargs={
                  'app': '', "should_reload": True}),
@@ -955,7 +912,6 @@ class TestCli(object):
         assert browser_mock.called == True
         assert result.exit_code == 0
 
-
     @patch('jbcli.cli.jb.Process')
     @patch('jbcli.cli.jb.time')
     @patch('jbcli.cli.jb.dockerutil')
@@ -964,8 +920,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         time_mock.sleep.side_effect = KeyboardInterrupt
-        runner = CliRunner()
-        result = runner.invoke(cli, ['watch', '--app', 'test', '--reload'])
+        result = invoke(['watch', '--app', 'test', '--reload'])
         assert process_mock.mock_calls == [
             call(target=dockerutil_mock.jb_watch, kwargs={
                  'app': 'test', "should_reload": True}),
@@ -975,7 +930,6 @@ class TestCli(object):
         assert browser_mock.called == True
         assert result.exit_code == 0
 
-
     @patch('jbcli.cli.jb.Process')
     @patch('jbcli.cli.jb.time')
     @patch('jbcli.cli.jb.dockerutil')
@@ -983,8 +937,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         time_mock.sleep.side_effect = KeyboardInterrupt
-        runner = CliRunner()
-        result = runner.invoke(cli, ['watch', '--includejs'])
+        result = invoke(['watch', '--includejs'])
 
         assert process_mock.mock_calls == [
             call(target=dockerutil_mock.jb_watch,
@@ -1003,13 +956,60 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         dockerutil_mock.halt.return_value = None
-        runner = CliRunner()
-        result = runner.invoke(cli, ['stop'])
+        result = invoke(['stop'])
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
             call.ensure_home(),
             call.is_running(),
             call.halt()
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
+    def test_start(self, dockerutil_mock):
+        """Starting brings docker-compose up in the environment of the cwd."""
+        dockerutil_mock.is_running.return_value = False
+        dockerutil_mock.ensure_home.return_value = True
+        result = invoke(['start', '--noupgrade'], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.is_running(),
+            call.pull(tag=None),
+            call.up(env=ANY)
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
+    def test_start_noupgrade(self, dockerutil_mock):
+        dockerutil_mock.is_running.return_value = False
+        dockerutil_mock.ensure_home.return_value = True
+        result = invoke(['start', '--noupgrade'])
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.is_running(),
+            call.pull(tag=None),
+            call.up(env=ANY)
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
+    def test_start_noupdate(self, dockerutil_mock):
+        dockerutil_mock.is_running.return_value = False
+        dockerutil_mock.ensure_home.return_value = True
+        result = invoke(['start', '--noupdate', '--noupgrade'])
+        assert dockerutil_mock.mock_calls == [
+            call.is_running(),
+            call.up(env=ANY)
+        ]
+        assert result.exit_code == 0
+
+    @patch('jbcli.cli.jb.dockerutil')
+    def test_start_already_running(self, dockerutil_mock):
+        dockerutil_mock.is_running.return_value = True
+        dockerutil_mock.ensure_home.return_value = True
+        result = invoke(['start', '--noupgrade'])
+
+        assert 'An instance of Juicebox is already running' in result.output
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.is_running()
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
@@ -1019,8 +1019,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, False]
         apps_mock.clone.return_value = 'git cookies'
         dockerutil_mock.is_running.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1040,8 +1039,7 @@ class TestCli(object):
     def test_clone_running_fail(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert dockerutil_mock.mock_calls == [call.is_running()]
         assert result.exit_code == 1
@@ -1052,8 +1050,7 @@ class TestCli(object):
     def test_clone_from_nonexist(self, os_mock, dockerutil_mock):
         os_mock.path.isdir.return_value = False
         dockerutil_mock.is_running.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert os_mock.mock_calls == [
             call.path.isdir('apps/cookies'),
@@ -1070,8 +1067,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, True]
         dockerutil_mock.is_running.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert os_mock.mock_calls == [
             call.path.isdir('apps/cookies'),
@@ -1091,8 +1087,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, False]
         apps_mock.clone.side_effect = ValueError('Cake Bad')
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1116,8 +1111,7 @@ class TestCli(object):
         apps_mock.clone.return_value = True
         os_mock.path.isdir.side_effect = [True, False]
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1140,8 +1134,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, False]
         apps_mock.clone.return_value = 'git cookies'
         dockerutil_mock.is_running.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1162,8 +1155,7 @@ class TestCli(object):
     def test_clone_running_fail_venv3(self, dockerutil_mock):
         dockerutil_mock.is_running.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert dockerutil_mock.mock_calls == [call.is_running()]
         assert result.exit_code == 1
@@ -1174,8 +1166,7 @@ class TestCli(object):
     def test_clone_from_nonexist_venv3(self, os_mock, dockerutil_mock):
         os_mock.path.isdir.return_value = False
         dockerutil_mock.is_running.return_value = True
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert os_mock.mock_calls == [
             call.path.isdir('apps/cookies'),
@@ -1192,8 +1183,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, True]
         dockerutil_mock.is_running.return_value = True
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert os_mock.mock_calls == [
             call.path.isdir('apps/cookies'),
@@ -1213,8 +1203,7 @@ class TestCli(object):
         os_mock.path.isdir.side_effect = [True, False]
         apps_mock.clone.side_effect = ValueError('Cake Bad')
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1238,8 +1227,7 @@ class TestCli(object):
         apps_mock.clone.return_value = True
         os_mock.path.isdir.side_effect = [True, False]
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
+        result = invoke(['clone', 'cookies', 'chocolate_chip', '--runtime', 'venv3'])
 
         assert apps_mock.mock_calls == [
             call.clone(u'chocolate_chip', 'apps/cookies',
@@ -1268,8 +1256,7 @@ class TestCli(object):
         os_mock.path.exists.return_value = False
         os_mock.symlink.return_value = False
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ['yo_upgrade'])
+        result = invoke(['yo_upgrade'])
 
         # TODO: Improve these tests
         assert proc_mock.mock_calls == [
@@ -1280,9 +1267,8 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_test_app(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
-        result = runner.invoke(cli, ['test_app', 'jb3demo'])
+        result = invoke(['test_app', 'jb3demo'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run(
                                                   'sh -c "cd apps/jb3demo; pwd; /venv/bin/python -m unittest discover tests"')]
@@ -1291,10 +1277,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_test_app_fail(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.run.side_effect = APIError('Fail')
-        result = runner.invoke(cli, ['test_app', 'jb3demo'])
+        result = invoke(['test_app', 'jb3demo'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run(
                                                   'sh -c "cd apps/jb3demo; pwd; /venv/bin/python -m unittest discover tests"')]
@@ -1304,9 +1289,8 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_test_app_venv3(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
-        result = runner.invoke(cli, ['test_app', 'jb3demo', '--runtime', 'venv3'])
+        result = invoke(['test_app', 'jb3demo', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run(
                                                   'sh -c "cd apps/jb3demo; pwd; /venv3/bin/python -m unittest discover tests"')]
@@ -1315,10 +1299,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_test_app_fail_venv3(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.run.side_effect = APIError('Fail')
-        result = runner.invoke(cli, ['test_app', 'jb3demo', '--runtime', 'venv3'])
+        result = invoke(['test_app', 'jb3demo', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run(
                                                   'sh -c "cd apps/jb3demo; pwd; /venv3/bin/python -m unittest discover tests"')]
@@ -1328,10 +1311,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_clear_cache(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
 
-        result = runner.invoke(cli, ['clear_cache'])
+        result = invoke(['clear_cache'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run('/venv/bin/python manage.py clear_cache '
                                                        '--settings=fruition.settings.docker')]
@@ -1340,10 +1322,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_clear_cache_not_running(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = False
 
-        result = runner.invoke(cli, ['clear_cache'])
+        result = invoke(['clear_cache'])
         assert dockerutil_mock.mock_calls == [
             call.is_running()
         ]
@@ -1351,10 +1332,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_clear_cache_venv3(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = True
 
-        result = runner.invoke(cli, ['clear_cache', '--runtime', 'venv3'])
+        result = invoke(['clear_cache', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [call.is_running(),
                                               call.run(
                                                   '/venv3/bin/python manage.py clear_cache '
@@ -1364,10 +1344,9 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_clear_cache_not_running_venv3(self, dockerutil_mock):
-        runner = CliRunner()
         dockerutil_mock.is_running.return_value = False
 
-        result = runner.invoke(cli, ['clear_cache', '--runtime', 'venv3'])
+        result = invoke(['clear_cache', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [
             call.is_running()
         ]
@@ -1375,9 +1354,7 @@ class TestCli(object):
 
     @patch('jbcli.cli.jb.dockerutil')
     def test_jb_pull(self, dockerutil_mock):
-        runner = CliRunner()
-
-        result = runner.invoke(cli, ['pull'])
+        result = invoke(['pull'])
         assert dockerutil_mock.mock_calls == [
             call.pull(None)
         ]
@@ -1388,8 +1365,7 @@ class TestCli(object):
     def test_clear_cache_fail(self, dockerutil_mock, click_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.run.side_effect = APIError('Failure')
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clear_cache'])
+        result = invoke(['clear_cache'])
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.run('/venv/bin/python manage.py clear_cache --settings=fruition.settings.docker')
@@ -1405,8 +1381,7 @@ class TestCli(object):
     def test_clear_cache_fail_venv3(self, dockerutil_mock, click_mock):
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.run.side_effect = APIError('Failure')
-        runner = CliRunner()
-        result = runner.invoke(cli, ['clear_cache', '--runtime', 'venv3'])
+        result = invoke(['clear_cache', '--runtime', 'venv3'])
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.run(
@@ -1427,8 +1402,7 @@ class TestCli(object):
         dockerutil_mock.is_running.return_value = Container(name='stable_juicebox_1')
         dockerutil_mock.check_home.return_value = None
         subprocess_mock.check_call.return_value = None
-        runner = CliRunner()
-        result = runner.invoke(cli, ['manage', 'test',  '--failfast', '--keepdb'])
+        result = invoke(['manage', 'test',  '--failfast', '--keepdb'])
         assert subprocess_mock.mock_calls == [
             call.check_call([
                 'docker', 'exec', '-it', 'stable_juicebox_1',
@@ -1442,8 +1416,7 @@ class TestCli(object):
         """When no container is running, and no --env is given, we give up."""
         dockerutil_mock.is_running.return_value = False
         dockerutil_mock.check_home.return_value = None
-        runner = CliRunner()
-        result = runner.invoke(cli, ['manage', 'test'])
+        result = invoke(['manage', 'test'])
         assert 'Juicebox not running and no --env given' in result.output
 
     @patch('jbcli.cli.jb.dockerutil')
@@ -1456,7 +1429,7 @@ class TestCli(object):
         dockerutil_mock.check_home.return_value = None
         subprocess_mock.check_call.return_value = None
 
-        result = CliRunner().invoke(cli, ['manage', '--env', 'core', 'test'])
+        result = invoke(['manage', '--env', 'core', 'test'])
         assert subprocess_mock.mock_calls == [
             call.check_call([
                 'docker', 'exec', '-it', 'core_juicebox_1',
@@ -1474,7 +1447,7 @@ class TestCli(object):
         subprocess_mock.check_call.side_effect = Exception("don't run this!")
         dockerutil_mock.run_jb.return_value = None
 
-        result = CliRunner().invoke(cli, ['manage', '--env', 'stable', 'test'])
+        result = invoke(['manage', '--env', 'stable', 'test'])
         assert dockerutil_mock.run_jb.mock_calls == [
             call(['/venv/bin/python', 'manage.py', 'test'], env=ANY)
         ]


### PR DESCRIPTION
Ticket: [OPS-1746](https://juiceanalytics.atlassian.net/browse/OPS-1746)

## Changes

- refactor CLI tests so we *always* pass `catch_exceptions=False`
  - required a tweak to test_yo_upgrade which was silently blowing up
- delete start, rename freshstart to start
- make the new start support the old behavior of running in the current directory's environment if no environment is specified
