### PR TITLE
"jb stop --clean" == "docker-compose down"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ ENV/
 # core local fruition symlink
 environments/core/fruition
 environments/py2core/fruition
+environments/hstm-core/hstm-juicebox
 environments/hstm-newcore/fruition
 
 

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -476,19 +476,7 @@ def start(ctx, env, noupdate, noupgrade, ssh):
         echo_warning('Run `jb stop` to stop this instance.')
         return
 
-    if env is None:
-        # If we're already in an environment directory, use it
-        abs_cwd = os.path.abspath('.')
-        if os.path.basename(os.path.dirname(abs_cwd)) == 'environments':
-            env = os.path.basename(abs_cwd)
-
-    os.chdir(DEVLANDIA_DIR)
-    if env is None:
-        env = get_environment_interactively()
-
-    if not env:
-        echo_highlight('No environment selected.')
-        return
+    env = get_environment_interactively(env)
 
     if not noupgrade:
         ctx.invoke(upgrade)
@@ -509,7 +497,17 @@ def start(ctx, env, noupdate, noupgrade, ssh):
     dockerutil.up(env=environ)
 
 
-def get_environment_interactively():
+def get_environment_interactively(env):
+    if env is None:
+        # If we're already in an environment directory, use it
+        abs_cwd = os.path.abspath('.')
+        if os.path.basename(os.path.dirname(abs_cwd)) == 'environments':
+            env = os.path.basename(abs_cwd)
+
+    os.chdir(DEVLANDIA_DIR)
+    if env:
+        return env
+
     click.echo("Welcome to devlandia!")
     click.echo('Gathering data on available environments...\n')
     # get a list of all the current images
@@ -559,26 +557,39 @@ def get_environment_interactively():
         {
             'type': 'list',
             'name': 'env',
-            'message': 'what environment would you like to start?',
+            'message': 'what environment would you like to use?',
             'choices': env_choices
         }
     ]
 
-    response = prompt(questions)
-    return response.get('env', None)
+    env = prompt(questions).get('env')
+
+    if not env:
+        echo_highlight('No environment selected.')
+        click.get_current_context().abort()
+
+    return env
 
 
 @cli.command()
+@click.option('--clean', default=False, help='clean up docker containers (using docker-compose down)',
+              is_flag=True)
+@click.option('--env', help='Which environment to use')
 @click.pass_context
-def stop(ctx):
+def stop(ctx, clean, env):
     """Stop a running juicebox in this environment
     """
+    env = get_environment_interactively(env)
+    os.chdir("./environments/{}".format(env))
     dockerutil.ensure_home()
 
     if not dockerutil.is_running():
         echo_highlight('Juicebox is not running')
     else:
-        dockerutil.halt()
+        if clean:
+            dockerutil.destroy()
+        else:
+            dockerutil.halt()
         echo_highlight('Juicebox is no longer running.')
 
 

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -583,14 +583,13 @@ def stop(ctx, clean, env):
     os.chdir("./environments/{}".format(env))
     dockerutil.ensure_home()
 
-    if not dockerutil.is_running():
-        echo_highlight('Juicebox is not running')
-    else:
-        if clean:
-            dockerutil.destroy()
-        else:
-            dockerutil.halt()
+    if clean:
+        dockerutil.destroy()
+    elif dockerutil.is_running():
+        dockerutil.halt()
         echo_highlight('Juicebox is no longer running.')
+    else:
+        echo_highlight('Juicebox is not running')
 
 
 @cli.command()

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -969,6 +969,20 @@ class TestCli(object):
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
+    def test_stop_clean(self, dockerutil_mock, monkeypatch):
+        monkeypatch.chdir(CORE_DIR)
+        dockerutil_mock.is_running.return_value = True
+        dockerutil_mock.ensure_home.return_value = True
+        dockerutil_mock.destroy.return_value = None
+        result = invoke(['stop', '--clean'])
+        assert result.exit_code == 0
+        assert dockerutil_mock.mock_calls == [
+            call.ensure_home(),
+            call.is_running(),
+            call.destroy()
+        ]
+
+    @patch('jbcli.cli.jb.dockerutil')
     def test_start(self, dockerutil_mock, monkeypatch):
         """Starting brings docker-compose up in the environment of the cwd."""
         monkeypatch.chdir(CORE_DIR)

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -955,7 +955,8 @@ class TestCli(object):
         assert result.exit_code == 0
 
     @patch('jbcli.cli.jb.dockerutil')
-    def test_stop(self, dockerutil_mock):
+    def test_stop(self, dockerutil_mock, monkeypatch):
+        monkeypatch.chdir(CORE_DIR)
         dockerutil_mock.is_running.return_value = True
         dockerutil_mock.ensure_home.return_value = True
         dockerutil_mock.halt.return_value = None

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -978,7 +978,6 @@ class TestCli(object):
         assert result.exit_code == 0
         assert dockerutil_mock.mock_calls == [
             call.ensure_home(),
-            call.is_running(),
             call.destroy()
         ]
 


### PR DESCRIPTION
Ticket: N/A

## Changes

* add a `--clean` flag to `jb stop` which does `docker-compose down`
* also add an `--env` parameter and use the new-style environment selection
