### PR TITLE
fix --ssh on python 3

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -401,7 +401,7 @@ def get_host_ip():
     # On linux, `host.docker.internal` doesn't work,
     # but we have a nice way to find the address w/ the docker0 interface.
     try:
-        ifname = 'docker0'
+        ifname = b'docker0'
         SIOCGIFADDR = 0x8915
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         interface = struct.pack('256s', ifname[:15])
@@ -414,7 +414,7 @@ def get_host_ip():
         # returns output like:
         #   192.168.1.1    host.docker.internal
         #   192.168.1.2    host.docker.internal
-        return out.splitlines()[0].split()[0]
+        return out.splitlines()[0].split()[0].decode('ascii')
 
 
 def activate_ssh(env, environ):

--- a/jbcli/jbcli/utils/secrets.py
+++ b/jbcli/jbcli/utils/secrets.py
@@ -22,9 +22,8 @@ def get_all_from_path(path):
     except Exception as e:
         print("[WARNING] couldn't fetch parameters under path", path, e)
         return {}
-    # These ENCODE calls probably need to change for python 3 support
     return {
-        param['Name'].rsplit('/', 1)[-1].encode('ascii'): param['Value'].encode('ascii')
+        param['Name'].rsplit('/', 1)[-1]: param['Value']
         for param in result['Parameters']
     }
 


### PR DESCRIPTION
Ticket: None

## Changes

There were a couple of bugs with using the `--ssh` parameter with Python 3.

- the `get_host_ip` function had a couple of str vs bytes issues
- the code which fetched secrets from parameter store was pointlessly encoding the keys / values to bytes -- this was no longer necessary since we started doing parameter store lookup *inside* the docker container. (we still need to fetch the parameters to get the value of certain redshift secrets to make `--ssh` support work, though)