### PR TITLE
pass through the FONTAWESOME_NPM_AUTH_TOKEN variable

### DIFF
--- a/environments/docker-compose.common.yml
+++ b/environments/docker-compose.common.yml
@@ -16,6 +16,7 @@ services:
       - DJANGO_SETTINGS_MODULE=fruition.settings.contained
       - REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
+      - FONTAWESOME_NPM_AUTH_TOKEN
 
       - JB_DB_NAME=juicebox
       - JB_DB_USERNAME=juicebox


### PR DESCRIPTION
Ticket: None

## Changes
- add `FONTAWESOME_NPM_AUTH_TOKEN` to the list of environment variables that are passed through when starting a jb instance, so we can run `npm install` in our containers