### PR TITLE
get py3-only fruition working again

### DIFF
--- a/environments/core/docker-compose.yml
+++ b/environments/core/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -U -q -r requirements.txt -r requirements_dev.txt ; /venv/bin/python docker/entrypoint.py"
     volumes:
       - ./fruition:/code
       - ../../apps:/code/apps

--- a/environments/hstm-newcore/docker-compose.yml
+++ b/environments/hstm-newcore/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:develop-py3"
-    command: bash -c "/venv/bin/pip install -U -q -r requirements3.txt -r requirements_dev.txt && /venv/bin/python docker/entrypoint.py"
+    command: bash -c "/venv/bin/pip install -U -q -r requirements.txt -r requirements_dev.txt ; /venv/bin/python docker/entrypoint.py"
     volumes:
       - ./fruition:/code
       - ../../apps:/code/apps


### PR DESCRIPTION
Ticket: [JB-XXXX](https://juiceanalytics.atlassian.net/browse/JB-XXXX)
Type: Fix/Improvement/Feature

## Changes

- the `pip install` commands in `core` and `hstm-newcore` now install `requirements.txt` instead of `requirements3.txt`, since fruition recently lost support for python 2 and we renamed `requirements3.txt` back to `requirements.txt`.
