### PR TITLE
OPS-1907 Expose Port 9001 for storybook

### DIFF
--- a/environments/docker-compose.common.yml
+++ b/environments/docker-compose.common.yml
@@ -4,6 +4,7 @@ services:
     ports:
       - "${DEVLANDIA_PORT}:8000"
       - "8888:8888"
+      - "9001:9001"
       - "2222:22"
     depends_on:
       - "redis"


### PR DESCRIPTION
Ticket: [OPS-1907](https://juiceanalytics.atlassian.net/browse/OPS-1907)
Type: Improvement

#### This PR introduces the following changes

- Exposes port 9001 so that you'll be able to access storybook after running `jb run npm run storybook` @meghna is this all that was desired for the Devlandia part?  I'm going to do another PR that builds storybook components in CodeBuild and the static assets will be explorable on deployed versions.