### PR TITLE
Support for running Ganesha along with JB in devlandia

### DIFF
--- a/environments/docker-compose.ganesha.yml
+++ b/environments/docker-compose.ganesha.yml
@@ -1,0 +1,20 @@
+# This is a "mixin" file that enables a local ganesha server
+# Whatever environment you apply this to has to have a symlink to a local ganesha checkout
+version: '3.2'
+services:
+  juicebox:
+    environment:
+      - JB_GANESHA_API=http://ganesha:3000
+      - JB_GANESHA_SIGNING_KEY=whatever
+      - JB_APPADMIN_SERVICE=http://localhost:3000
+  ganesha:
+    image: "976661725066.dkr.ecr.us-east-1.amazonaws.com/ganesha-dev:latest"
+    command: "npm run start:dev"
+    volumes:
+      - ./ganesha:/ganesha
+    ports:
+      - "5050:5050"
+      - "3000:3000"
+    environment:
+      - ENVIRONMENT=local
+      - JB_GANESHA_SIGNING_KEY_DOCKER=whatever

--- a/environments/docker-compose.ganesha.yml
+++ b/environments/docker-compose.ganesha.yml
@@ -17,4 +17,4 @@ services:
       - "3000:3000"
     environment:
       - ENVIRONMENT=local
-      - JB_GANESHA_SIGNING_KEY_DOCKER=whatever
+      - JB_GANESHA_SIGNING_KEY=whatever

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -738,13 +738,14 @@ def _run(args, env, service='juicebox'):
 @cli.command()
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.option("--env", help="Which environment to run docker-compose for")
-def dc(args, env):
+@click.option("--ganesha", default=False, is_flag=True, help="Enable ganesha")
+def dc(args, env, ganesha):
     """Run docker-compose in a particular environment"""
     cmd = list(args)
     if env is None:
         env = dockerutil.check_home()
     os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
-    dockerutil.docker_compose(cmd)
+    dockerutil.docker_compose(cmd, ganesha=ganesha)
 
 
 @cli.command()

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -468,8 +468,10 @@ def activate_ssh(env, environ):
               is_flag=True)
 @click.option('--ssh', default=False, is_flag=True,
               help='run an SSH tunnel for redshift')
+@click.option("--ganesha", default=False, is_flag=True,
+              help="Enable ganesha")
 @click.pass_context
-def start(ctx, env, noupdate, noupgrade, ssh):
+def start(ctx, env, noupdate, noupgrade, ssh, ganesha):
     """Configure the environment and start Juicebox"""
     if dockerutil.is_running():
         echo_warning('An instance of Juicebox is already running')
@@ -494,7 +496,7 @@ def start(ctx, env, noupdate, noupgrade, ssh):
     cleanup_ssh(env)
     if ssh:
         activate_ssh(env, environ)
-    dockerutil.up(env=environ)
+    dockerutil.up(env=environ, ganesha=ganesha)
 
 
 def get_environment_interactively(env):
@@ -701,17 +703,18 @@ def manage(args, env):
 ))
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.option('--env', help='Which environment to use')
-def run(args, env):
+@click.option('--service', help='Which service to run the command in')
+def run(args, env, service):
     """Run an arbitrary command in the JB container"""
-    return _run(args, env)
+    return _run(args, env, service)
 
 
-def _run(args, env):
+def _run(args, env, service='juicebox'):
     cmd = list(args)
     if env is None:
         env = dockerutil.check_home()
 
-    container = dockerutil.is_running()
+    container = dockerutil.is_running(service=service)
     try:
         if container and (env is None or container.name.startswith(env)):
             click.echo("running command in {}".format(container.name))
@@ -721,7 +724,7 @@ def _run(args, env):
         elif env is not None:
             click.echo("starting new {}".format(env))
             os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
-            dockerutil.run_jb(cmd, env=populate_env_with_secrets())
+            dockerutil.run_jb(cmd, env=populate_env_with_secrets(), service=service)
         else:
             echo_warning(
                 "Juicebox not running and no --env given. "
@@ -730,6 +733,18 @@ def _run(args, env):
     except subprocess.CalledProcessError as e:
         echo_warning("command exited with {}".format(e.returncode))
         click.get_current_context().abort()
+
+
+@cli.command()
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
+@click.option("--env", help="Which environment to run docker-compose for")
+def dc(args, env):
+    """Run docker-compose in a particular environment"""
+    cmd = list(args)
+    if env is None:
+        env = dockerutil.check_home()
+    os.chdir(os.path.join(DEVLANDIA_DIR, 'environments', env))
+    dockerutil.docker_compose(cmd)
 
 
 @cli.command()

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -703,7 +703,7 @@ def manage(args, env):
 ))
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.option('--env', help='Which environment to use')
-@click.option('--service', help='Which service to run the command in')
+@click.option('--service', help='Which service to run the command in', default='juicebox')
 def run(args, env, service):
     """Run an arbitrary command in the JB container"""
     return _run(args, env, service)

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -993,7 +993,7 @@ class TestCli(object):
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.pull(tag=None),
-            call.up(env=ANY)
+            call.up(env=ANY, ganesha=False)
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
@@ -1006,7 +1006,7 @@ class TestCli(object):
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
             call.pull(tag=None),
-            call.up(env=ANY)
+            call.up(env=ANY, ganesha=False)
         ]
 
     @patch('jbcli.cli.jb.dockerutil')
@@ -1017,7 +1017,7 @@ class TestCli(object):
         result = invoke(['start', '--noupdate', '--noupgrade'])
         assert dockerutil_mock.mock_calls == [
             call.is_running(),
-            call.up(env=ANY)
+            call.up(env=ANY, ganesha=False)
         ]
         assert result.exit_code == 0
 
@@ -1468,7 +1468,7 @@ class TestCli(object):
 
         result = invoke(['manage', '--env', 'stable', 'test'])
         assert dockerutil_mock.run_jb.mock_calls == [
-            call(['/venv/bin/python', 'manage.py', 'test'], env=ANY)
+            call(['/venv/bin/python', 'manage.py', 'test'], env=ANY, service='juicebox')
         ]
         name, args, kwargs = dockerutil_mock.run_jb.mock_calls[0]
         assert kwargs['env']['test_secret'] == 'true'


### PR DESCRIPTION
Ticket: N/A

## Changes

Primarily, this PR adds a `--ganesha` flag to `jb start` that runs ganesha.

- it only supports "core"-style ganesha for now, so your environment must have a symlink to ganesha's git checkout
- it configures the JB & ganesha to point to each other
- `jb run` also gets a `--service` argument to specify which service to run a command in, useful for manual dev commands you want to run in ganesha.

Unrelated:

- I also added a `jb dc` command for running `docker-compose` with arbitrary arguments, but configured with all of the relevant docker-compose configuration files for a particular environment. I found this useful while doing tricky manual tasks so I don't have to manually pass all the `-f` arguments to `docker-compose`
