### PR TITLE
expose port 6006 so we can run `npm run storybook`

### DIFF
--- a/environments/docker-compose.ganesha.yml
+++ b/environments/docker-compose.ganesha.yml
@@ -15,6 +15,7 @@ services:
     ports:
       - "5050:5050"
       - "3000:3000"
+      - "6006:6006"
     environment:
       - ENVIRONMENT=local
       - JB_GANESHA_SIGNING_KEY=whatever


### PR DESCRIPTION
## Changes

- export port 6006 so `jb run --service ganesha npm run storybook` can do something useful