### PR TITLE
OPS-1988 Bump Postgres up to 12.4

### DIFF
--- a/environments/docker-compose.common.yml
+++ b/environments/docker-compose.common.yml
@@ -55,6 +55,6 @@ services:
       - POSTGRES_USER=juicebox
       - POSTGRES_PASSWORD=juicebox
       - POSTGRES_DB=juicebox
-    image: "postgres:9.5.15-alpine"
+    image: "postgres:12.4-alpine"
   redis:
     image: "redis:4.0.14"


### PR DESCRIPTION
Ticket: [OPS-1988](https://juiceanalytics.atlassian.net/browse/OPS-1988)
Type: Improvement

#### This PR introduces the following changes

- So everything will be consistent with the deployed versions, bump Devlandia's version of Postgres to 12.4.  Dev is already upgraded, we will be upgrading prod when release/3.56 is released.