### PR TITLE
remove some support for the old `hstm-` environments

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -455,12 +455,10 @@ def start(ctx, env, noupdate, noupgrade, ssh, ganesha):
     stash.put('current_env', env)
     os.chdir("./environments/{}".format(env))
     environ = populate_env_with_secrets()
-    if env.startswith('hstm-') and not env.startswith('hstm-new'):
-        activate_hstm()
 
     if not noupdate:
         dockerutil.pull(tag=None)
-    if env.startswith('hstm-new'):
+    if env.startswith("hstm-"):
         activate_hstm()
     cleanup_ssh(env)
     if ssh:


### PR DESCRIPTION
Ticket: N/A


## Changes

since the old hstm environments are now gone, we don't need to have special case code in jbcli to handle them.

The old-style HSTM environments needed to pull images from the HSTM account, whereas the new HSTM environments need to pull from our regular juice (legacy) AWS account. We don't need to support that pull-from-HSTM any more