### PR TITLE
changed setup script to use python3.7

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,7 +23,7 @@ if [ ! -e ~/.ssh/insecure_key ]; then
 fi
 
 echo "creating virtualenv \"devlandia\"..."
-mkvirtualenv devlandia -p python2.7
+mkvirtualenv devlandia -p python3.7
 echo "cd $PWD" >> ~/.virtualenvs/devlandia/bin/postactivate
 
 echo "activating virtualenv \"devlandia\""


### PR DESCRIPTION
Ticket: none
Type: Fix

#### This PR introduces the following changes
- The setup script that is meant to automate setup for users which is mentioned in the docs was building a python2.7 virtual env so it's now updated to attempt to build python3.7