### PR TITLE
[OPS-2105] Improve error reporting output

### DIFF
--- a/jbcli/jbcli/utils/subprocess.py
+++ b/jbcli/jbcli/utils/subprocess.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 
 import subprocess
 from subprocess import CalledProcessError
+from .format import echo_warning
+import sys
 
 __all__ = ['CalledProcessError', 'check_call', 'check_output']
 
@@ -14,7 +16,13 @@ except:
 def check_call(args, env=None):
     if win32api is not None:
         args[0] = win32api.FindExecutable(args[0])[1]
-    return subprocess.check_call(args, env=env)
+    try:
+        subprocess.check_call(args, env=env)
+    except subprocess.CalledProcessError as e:
+        echo_warning(f"Error:\n      {e}\n")
+        sys.exit(1)
+
+    # return subprocess.check_call(args, env=env)
 
 def check_output(args, env=None):
     if win32api is not None:

--- a/jbcli/jbcli/utils/subprocess.py
+++ b/jbcli/jbcli/utils/subprocess.py
@@ -22,8 +22,6 @@ def check_call(args, env=None):
         echo_warning(f"Error:\n      {e}\n")
         sys.exit(1)
 
-    # return subprocess.check_call(args, env=env)
-
 def check_output(args, env=None):
     if win32api is not None:
         args[0] = win32api.FindExecutable(args[0])[1]

--- a/jbcli/jbcli/utils/subprocess.py
+++ b/jbcli/jbcli/utils/subprocess.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import subprocess
 from subprocess import CalledProcessError
 from .format import echo_warning
-import sys
 
 __all__ = ['CalledProcessError', 'check_call', 'check_output']
 


### PR DESCRIPTION
Ticket: [OPS-2105](https://juiceanalytics.atlassian.net/browse/OPS-2105)
Type: Improvement

#### This PR introduces the following changes

- updated check_call to remove traceback and only print specific error

Previously looked like this: 

```
Traceback (most recent call last):
  File "/Users/david.paul/.virtualenvs/devlandia/bin/jb", line 33, in <module>
    sys.exit(load_entry_point('jbcli', 'console_scripts', 'jb')())
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/david.paul/.virtualenvs/devlandia/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/david.paul/Desktop/devlandia/jbcli/jbcli/cli/jb.py", line 466, in start
    dockerutil.up(env=environ, ganesha=ganesha)
  File "/Users/david.paul/Desktop/devlandia/jbcli/jbcli/utils/dockerutil.py", line 93, in up
    docker_compose(['up', '--abort-on-container-exit'], env=env, ganesha=ganesha)
  File "/Users/david.paul/Desktop/devlandia/jbcli/jbcli/utils/dockerutil.py", line 87, in docker_compose
    return check_call(cmd + file_args + args, env=env)
  File "/Users/david.paul/Desktop/devlandia/jbcli/jbcli/utils/subprocess.py", line 25, in check_call
    return subprocess.check_call(args, env=env)
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['docker-compose', '--project-directory', '.', '--project-name', 'core', '-f', '../docker-compose.common.yml', '-f', 'docker-compose.yml', 'up', '--abort-on-container-exit']' returned non-zero exit status 1.
```
now it just does: 

```
Error:
      Command '['docker-compose', '--project-directory', '.', '--project-name', 'core', '-f', '../docker-compose.common.yml', '-f', 'docker-compose.yml', 'up', '--abort-on-container-exit']' returned non-zero exit status 1.
```

I attempted to do the same with `check_output` but couldn't figure out a way that it did not cause errors that were not there previously. I am open to new ideas though
