### PR TITLE
[OPS-2127] Fix pip install for core usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.2'
 services:
   juicebox:
     image: "423681189101.dkr.ecr.us-east-1.amazonaws.com/juicebox-devlandia:${TAG}"
-    command: bash -c "/venv/bin/python docker/entrypoint.py"
+    command: bash -c "if [ '${WORKFLOW}' = 'core' ] ; then
+                /venv/bin/pip install -U -q -r requirements.txt -r requirements_dev.txt ;
+            fi ; /venv/bin/python docker/entrypoint.py"
     volumes:
       - ./apps:/code/apps
       - ~/.boto:/root/.boto:ro

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -385,12 +385,13 @@ def start(ctx, env, noupdate, noupgrade, ssh, ganesha, hstm, core):
     env = get_environment_interactively(env, tag_replacements)
     core_path = "readme"
     core_end = "unused"
-
+    workflow = "dev"
 
     if "core" in env or core:
         if os.path.exists("fruition"):
             core_path = "fruition"
             core_end = "code"
+            workflow = "core"
         else:
             print("Could not find Local Fruition Checkout, please check that it is symlinked to the top level of Devlandia")
             sys.exit()
@@ -404,7 +405,11 @@ def start(ctx, env, noupdate, noupgrade, ssh, ganesha, hstm, core):
 
     stash.put('current_env', tag)
     env_dot = open(".env", "w")
-    env_dot.write(f"DEVLANDIA_PORT=8000\nTAG={tag}\nFRUITION={core_path}\nFILE={core_end}")
+    env_dot.write(f"DEVLANDIA_PORT=8000\n"
+                  f"TAG={tag}\n"
+                  f"FRUITION={core_path}\n"
+                  f"FILE={core_end}\n"
+                  f"WORKFLOW={workflow}")
     env_dot.close()
 
     environ = populate_env_with_secrets()


### PR DESCRIPTION
Ticket: [OPS-2127](https://juiceanalytics.atlassian.net/browse/OPS-2127)
Type: Fix

#### This PR introduces the following changes

- there was a difference in the way that core stuff was handling pip installation in the docker compose file that got deleted when everything got combined, so I added a conditional that checks to see if it's dev work or core work and will run the pip install stuff for core work so new requirements will be correctly loaded