### PR TITLE
fix "jb run" and "jb manage" creating new containers even when jb is already running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,8 +94,7 @@ ENV/
 .yo-rc.json
 
 # core local fruition symlink
-fruition
 .env
 docker-compose-ssh.yml
-recipe/
-fruition/
+recipe
+fruition

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -579,7 +579,7 @@ def _run(args, env, service='juicebox'):
 
     container = dockerutil.is_running(service=service)
     try:
-        if container and (env is None or container.name.startswith(env)):
+        if container:
             click.echo("running command in {}".format(container.name))
             # we don't use docker-py for this because it doesn't support the equivalent of
             # "--interactive --tty"

--- a/jbcli/jbcli/tests/test_cli.py
+++ b/jbcli/jbcli/tests/test_cli.py
@@ -1360,21 +1360,3 @@ class TestCli(object):
                 '/venv/bin/python', 'manage.py', 'test'])
         ]
         assert result.exit_code == 0
-
-    @patch('jbcli.cli.jb.dockerutil')
-    @patch('jbcli.cli.jb.subprocess')
-    def test_jb_manage_running_not_matching_env(self, subprocess_mock, dockerutil_mock):
-        """When an --env is given, and there is no matching container, we run a new one.
-        """
-        dockerutil_mock.is_running.return_value = Container(name='core_juicebox_1')
-        dockerutil_mock.check_home.return_value = None
-        subprocess_mock.check_call.side_effect = Exception("don't run this!")
-        dockerutil_mock.run_jb.return_value = None
-
-        result = invoke(['manage', '--env', 'stable', 'test'])
-        assert dockerutil_mock.run_jb.mock_calls == [
-            call(['/venv/bin/python', 'manage.py', 'test'], env=ANY, service='juicebox')
-        ]
-        name, args, kwargs = dockerutil_mock.run_jb.mock_calls[0]
-        assert kwargs['env']['test_secret'] == 'true'
-        assert result.exit_code == 0


### PR DESCRIPTION
## Changes

- the `jb run` / `jb manage` shared logic would try to run the command in an existing JB container. This logic broke recently because the code would check if the container name had the environment name in it. but now the environment name is no longer in the container name, so I've removed that check.