### PR TITLE
OPS-2228 Fix case where prompting for auth token was being skipped

### DIFF
--- a/jbcli/jbcli/utils/auth.py
+++ b/jbcli/jbcli/utils/auth.py
@@ -82,6 +82,12 @@ def set_creds():
         else:
             echo_warning('Profile not selected, exiting.')
             exit(1)
+    elif len(profile_details) == 1:
+        token = input("Please enter MFA Code: ")
+        output = json.loads(check_output(['aws', 'sts', 'get-session-token', '--profile', f'{profile_details[0][0]}',
+                                          '--serial-number', f'{profile_details[0][1]}', '--token-code', f'{token}',
+                                          '--duration-seconds', '86400']))
+        set_and_cache_creds(output)
 
 
 def check_cred_validity(aws_access_key_id, aws_secret_access_key, aws_session_token):


### PR DESCRIPTION
Ticket: [OPS-2228](https://juiceanalytics.atlassian.net/browse/OPS-2228)
Type: Fix

#### This PR introduces the following changes

- Fixes a case where devlandia would fail to prompt the user at startup if they only had 1 profile set in their config file.  We hadn't run into this yet since everyone had multiple sets of credentials/profiles configured, but while Ted was getting setup we noticed this failure.