### PR TITLE
Remove get_parameters_by_path from access token validity

### DIFF
--- a/jbcli/jbcli/utils/auth.py
+++ b/jbcli/jbcli/utils/auth.py
@@ -17,21 +17,28 @@ def has_current_session():
         return
     stash = Stash("~/.config/juicebox/creds.toml")
     try:
-        access_key = stash.get('AWS_ACCESS_KEY_ID')
+        access_key = stash.get("AWS_ACCESS_KEY_ID")
         if access_key is None:
-            echo_warning("AWS Variables not found locally, you'll be prompted to reauthenticate.")
+            echo_warning(
+                "AWS Variables not found locally, you'll be prompted to reauthenticate."
+            )
             set_creds()
         else:
-            echo_success("Checking existing credentials to see if the session is still valid.")
+            echo_success(
+                "Checking existing credentials to see if the session is still valid."
+            )
             load_creds()
-            valid = check_cred_validity(aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-                                        aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
-                                        aws_session_token=os.environ['AWS_SESSION_TOKEN']
-                                        )
+            valid = check_cred_validity(
+                aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+                aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+                aws_session_token=os.environ["AWS_SESSION_TOKEN"],
+            )
             if not valid:
                 set_creds()
     except ClientError as e:
-        echo_warning(f"Client error, session doesn't appear to be valid, reauthenticating: {e}")
+        echo_warning(
+            f"Client error, session doesn't appear to be valid, reauthenticating: {e}"
+        )
 
 
 def set_creds():
@@ -44,81 +51,125 @@ def set_creds():
         echo_success("Found ~/.aws/config file.")
         for section in config.sections():
             try:
-                parsed = section.replace('profile ', '') if 'profile' in section else section
-                if config.get(section, 'mfa_serial'):
-                    details = (parsed, config.get(section, 'mfa_serial'))
+                parsed = (
+                    section.replace("profile ", "") if "profile" in section else section
+                )
+                if config.get(section, "mfa_serial"):
+                    details = (parsed, config.get(section, "mfa_serial"))
                     profile_details.append(details)
             except Exception as e:
-                profile_details.append((parsed, 'No MFA device'))
+                profile_details.append((parsed, "No MFA device"))
     except Exception as e:
         print(e)
     if len(profile_details) > 1:
         choices = [
-            {'name': k[0] + ' - ' + k[1], 'value': (k[0], k[1])}
+            {"name": k[0] + " - " + k[1], "value": (k[0], k[1])}
             for k in profile_details
         ]
 
         questions = [
             {
-                'type': 'list',
-                'name': 'profile',
-                'message': 'What profile and MFA device would you like to use?',
-                'choices': choices
+                "type": "list",
+                "name": "profile",
+                "message": "What profile and MFA device would you like to use?",
+                "choices": choices,
             }
         ]
 
-        profile = prompt(questions).get('profile')
-        if profile and profile[1] != 'No MFA device':
+        profile = prompt(questions).get("profile")
+        if profile and profile[1] != "No MFA device":
             token = input("Please enter MFA Code: ")
             output = json.loads(
-                check_output(['aws', 'sts', 'get-session-token', '--profile', f'{profile[0]}', '--serial-number',
-                              f'{profile[1]}', '--token-code', f'{token}', '--duration-seconds', '86400']))
+                check_output(
+                    [
+                        "aws",
+                        "sts",
+                        "get-session-token",
+                        "--profile",
+                        f"{profile[0]}",
+                        "--serial-number",
+                        f"{profile[1]}",
+                        "--token-code",
+                        f"{token}",
+                        "--duration-seconds",
+                        "86400",
+                    ]
+                )
+            )
             set_and_cache_creds(output)
         elif profile:
             output = json.loads(
-                check_output(['aws', 'sts', 'get-session-token', '--profile', f'{profile[0]}', '--duration-seconds',
-                              '86400']))
+                check_output(
+                    [
+                        "aws",
+                        "sts",
+                        "get-session-token",
+                        "--profile",
+                        f"{profile[0]}",
+                        "--duration-seconds",
+                        "86400",
+                    ]
+                )
+            )
             set_and_cache_creds(output)
         else:
-            echo_warning('Profile not selected, exiting.')
+            echo_warning("Profile not selected, exiting.")
             exit(1)
     elif len(profile_details) == 1:
         token = input("Please enter MFA Code: ")
-        output = json.loads(check_output(['aws', 'sts', 'get-session-token', '--profile', f'{profile_details[0][0]}',
-                                          '--serial-number', f'{profile_details[0][1]}', '--token-code', f'{token}',
-                                          '--duration-seconds', '86400']))
+        output = json.loads(
+            check_output(
+                [
+                    "aws",
+                    "sts",
+                    "get-session-token",
+                    "--profile",
+                    f"{profile_details[0][0]}",
+                    "--serial-number",
+                    f"{profile_details[0][1]}",
+                    "--token-code",
+                    f"{token}",
+                    "--duration-seconds",
+                    "86400",
+                ]
+            )
+        )
         set_and_cache_creds(output)
 
 
 def check_cred_validity(aws_access_key_id, aws_secret_access_key, aws_session_token):
-    ecr_test = boto3.client('ecr', aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key,
-                            aws_session_token=aws_session_token)
-    ssm_test = boto3.client('ssm', aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key,
-                            aws_session_token=aws_session_token)
+    ecr_test = boto3.client(
+        "ecr",
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_session_token=aws_session_token,
+    )
+    ssm_test = boto3.client(
+        "ssm",
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_session_token=aws_session_token,
+    )
     try:
         ecr_test.describe_images(
-            registryId='423681189101',
-            repositoryName='juicebox-devlandia',
+            registryId="423681189101",
+            repositoryName="juicebox-devlandia",
             imageIds=[
-                {
-                    'imageTag': 'develop-py3'
-                },
-            ]
+                {"imageTag": "develop-py3"},
+            ],
         )
         # added a 2nd test because i was getting the check passing somehow for the first but not this one
         ssm_test.get_parameters_by_path(
-            Path=' /jb-deployment-vars/devlandia/',
-            Recursive=True,
-            WithDecryption=True
+            Path=" /jb-deployment-vars/devlandia/", Recursive=True, WithDecryption=True
         )
 
         echo_success("Credentials are valid.")
         return True
 
     except Exception as e:
-        del os.environ['AWS_ACCESS_KEY_ID']
-        del os.environ['AWS_SECRET_ACCESS_KEY']
-        del os.environ['AWS_SESSION_TOKEN']
+        del os.environ["AWS_ACCESS_KEY_ID"]
+        del os.environ["AWS_SECRET_ACCESS_KEY"]
+        del os.environ["AWS_SESSION_TOKEN"]
         echo_warning("Credentials not valid, prompting for reauthentication.")
         return False
 
@@ -126,17 +177,17 @@ def check_cred_validity(aws_access_key_id, aws_secret_access_key, aws_session_to
 def load_creds():
     echo_success("Loading cached credentials")
     stash = Stash("~/.config/juicebox/creds.toml")
-    os.environ['AWS_ACCESS_KEY_ID'] = stash.get('AWS_ACCESS_KEY_ID')
-    os.environ['AWS_SECRET_ACCESS_KEY'] = stash.get('AWS_SECRET_ACCESS_KEY')
-    os.environ['AWS_SESSION_TOKEN'] = stash.get('AWS_SESSION_TOKEN')
+    os.environ["AWS_ACCESS_KEY_ID"] = stash.get("AWS_ACCESS_KEY_ID")
+    os.environ["AWS_SECRET_ACCESS_KEY"] = stash.get("AWS_SECRET_ACCESS_KEY")
+    os.environ["AWS_SESSION_TOKEN"] = stash.get("AWS_SESSION_TOKEN")
 
 
 def set_and_cache_creds(output):
     stash = Stash("~/.config/juicebox/creds.toml")
-    os.environ['AWS_ACCESS_KEY_ID'] = output['Credentials']['AccessKeyId']
-    os.environ['AWS_SECRET_ACCESS_KEY'] = output['Credentials']['SecretAccessKey']
-    os.environ['AWS_SESSION_TOKEN'] = output['Credentials']['SessionToken']
+    os.environ["AWS_ACCESS_KEY_ID"] = output["Credentials"]["AccessKeyId"]
+    os.environ["AWS_SECRET_ACCESS_KEY"] = output["Credentials"]["SecretAccessKey"]
+    os.environ["AWS_SESSION_TOKEN"] = output["Credentials"]["SessionToken"]
 
-    stash.put("AWS_ACCESS_KEY_ID", output['Credentials']['AccessKeyId'])
-    stash.put("AWS_SECRET_ACCESS_KEY", output['Credentials']['SecretAccessKey'])
-    stash.put("AWS_SESSION_TOKEN", output['Credentials']['SessionToken'])
+    stash.put("AWS_ACCESS_KEY_ID", output["Credentials"]["AccessKeyId"])
+    stash.put("AWS_SECRET_ACCESS_KEY", output["Credentials"]["SecretAccessKey"])
+    stash.put("AWS_SESSION_TOKEN", output["Credentials"]["SessionToken"])

--- a/jbcli/jbcli/utils/auth.py
+++ b/jbcli/jbcli/utils/auth.py
@@ -144,12 +144,6 @@ def check_cred_validity(aws_access_key_id, aws_secret_access_key, aws_session_to
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
     )
-    ssm_test = boto3.client(
-        "ssm",
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_session_token=aws_session_token,
-    )
     try:
         ecr_test.describe_images(
             registryId="423681189101",
@@ -158,15 +152,11 @@ def check_cred_validity(aws_access_key_id, aws_secret_access_key, aws_session_to
                 {"imageTag": "develop-py3"},
             ],
         )
-        # added a 2nd test because i was getting the check passing somehow for the first but not this one
-        ssm_test.get_parameters_by_path(
-            Path=" /jb-deployment-vars/devlandia/", Recursive=True, WithDecryption=True
-        )
 
         echo_success("Credentials are valid.")
         return True
 
-    except Exception as e:
+    except Exception:
         del os.environ["AWS_ACCESS_KEY_ID"]
         del os.environ["AWS_SECRET_ACCESS_KEY"]
         del os.environ["AWS_SESSION_TOKEN"]


### PR DESCRIPTION
## Changes

- format with black
- don't call get_parameters_by_path in check_cred_validity, since we are changing things so that won't work for our contractors.

(reviewer note: you can just skip the black commit and individually review the other commit for sanity)

I didn't replace it with anything else because I don't think we really need to check it anyway.