### PR TITLE
OPS-2353 Docker Prune

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -16,6 +16,8 @@ import re
 import sys
 import os
 import shutil
+import threading
+import subprocess
 
 import click
 import docker.errors
@@ -57,12 +59,12 @@ class WatchHandler(FileSystemEventHandler):
                 # Try to load app via api, fall back to calling docker.exec_run
                 if not load_app(app):
                     run(f"/venv/bin/python manage.py loadjuiceboxapp {app}")
-                echo_success("{} was added successfully.".format(app))
+                echo_success(f"{app} was added successfully.")
                 if self.should_reload:
                     refresh_browser()
 
         else:
-            click.echo("Change to {} ignored".format(event.src_path))
+            click.echo(f"Change to {event.src_path} ignored")
 
         click.echo("Waiting for changes...")
 
@@ -125,7 +127,7 @@ def ensure_root():
     if not os.path.isdir("jbcli"):
         # We're not in the devlandia root
         echo_warning(
-            "Please run this command from inside the Devlandia root " "directory."
+            "Please run this command from inside the Devlandia root directory."
         )
         click.get_current_context().abort()
     return True
@@ -313,7 +315,7 @@ def set_tag(env, tag):
     """Set an environment to use a tagged image"""
     ensure_root()
 
-    os.chdir("./environments/{}".format(env))
+    os.chdir(f"./environments/{env}")
     changed = False
     with open("./docker-compose.yml", "rt") as dc:
         with open("out.txt", "wt") as out:
@@ -330,7 +332,7 @@ def set_tag(env, tag):
     else:
         os.remove("./out.txt")
 
-    echo_success("Environment {} is using {}".format(env, tag))
+    echo_success(f"Environment {env} is using {tag}")
     os.chdir("../..")
 
 

--- a/jbcli/jbcli/utils/subprocess.py
+++ b/jbcli/jbcli/utils/subprocess.py
@@ -3,7 +3,7 @@ import sys
 from subprocess import CalledProcessError
 from .format import echo_warning
 
-__all__ = ['CalledProcessError', 'check_call', 'check_output']
+__all__ = ['CalledProcessError', 'check_call', 'check_output', 'popen']
 
 try:
     import win32api

--- a/jbcli/jbcli/utils/subprocess.py
+++ b/jbcli/jbcli/utils/subprocess.py
@@ -10,6 +10,7 @@ try:
 except:
     win32api = None
 
+
 def check_call(args, env=None):
     if win32api is not None:
         args[0] = win32api.FindExecutable(args[0])[1]
@@ -19,7 +20,14 @@ def check_call(args, env=None):
         echo_warning(f"Error:\n      {e}\n")
         sys.exit(1)
 
+
 def check_output(args, env=None):
     if win32api is not None:
         args[0] = win32api.FindExecutable(args[0])[1]
     return subprocess.check_output(args, env=env)
+
+
+def popen(args, env=None):
+    if win32api is not None:
+        args[0] = win32api.FindExecutable(args[0])[1]
+    return subprocess.Popen(args, env=env, shell=True)


### PR DESCRIPTION
Ticket: [OPS-2353](https://juiceanalytics.atlassian.net/browse/OPS-2353)
Type: Improvement

#### This PR introduces the following changes

- Added new functionality that will automatically clean dangling docker images.  When you first start with the new version it will prompt you to set a delay value in seconds.  This value is stored in the devlandia.toml file.   This is how long the docker system prune thread waits before running.  I did it this way because it's possible that if you run jb start and realize you're on the wrong branch the desired image may have been cleaned up.  I thought it would be easiest to let everyone set their own delay since they know their habits best.
- If you want to change this value later run `jb delay` and you'll be prompted to enter a new value.
- By default, the command that is run is `docker system prune -f` this only deletes dangling images.  If you want to delete all unused images, not only dangling ones, pass this flag, --prune-all, in your jb start command
- Misc. cleanups, sourcery suggested changing formatted strings to f-strings.
- Bumped minor version