### PR TITLE
don't "set_creds" unless we're actually starting a new container

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -838,7 +838,6 @@ def run(args, env, service):
 
 
 def _run(args, env, service="juicebox"):
-    auth.set_creds()
     cmd = list(args)
     if env is None:
         env = dockerutil.check_home()
@@ -853,6 +852,7 @@ def _run(args, env, service="juicebox"):
         elif env is not None:
             click.echo("starting new {}".format(env))
             os.chdir(DEVLANDIA_DIR)
+            auth.set_creds()
             dockerutil.run_jb(cmd, env=populate_env_with_secrets(), service=service)
         else:
             echo_warning(


### PR DESCRIPTION
## Change

Don't call set_creds unless we're actually in a codepath that's going to need it -- if you `jb run /bin/bash` or `jb manage test` and there's already a container running, we don't need to ask for new creds.