### PR TITLE
JB-5135 The temporary container is removed during start-up.

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -282,7 +282,7 @@ def get_host_ip():
             "[get_host_ip] Couldn't get docker0 address, falling back to slow method", e
         )
         out = dockerutil.client.containers.run(
-            "ubuntu:18.04", "getent hosts host.docker.internal"
+            "ubuntu:18.04", "getent hosts host.docker.internal", remove=True
         )
         # returns output like:
         #   192.168.1.1    host.docker.internal


### PR DESCRIPTION
Ticket: [JB-5135](https://juiceanalytics.atlassian.net/browse/JB-5135)
Type: Fix/Improvement/Feature

#### This PR introduces the following changes

A temporary container is created when `jb start` is ran to discover an IP address, and this leads to several junk containers after a few weeks of starting and stopping `jb` every day.  This will remove that temporary container after it's done during start-up, freeing the user of clutter-containers.

## Documentation

Tested on my local machine.
<img width="748" alt="Screenshot 2023-01-04 at 2 10 24 PM" src="https://user-images.githubusercontent.com/118456968/210631134-368947ff-4a66-4e23-95ba-9f6049cd68e5.png">


## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests


[JB-5135]: https://juiceanalytics.atlassian.net/browse/JB-5135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JB-5135]: https://juiceanalytics.atlassian.net/browse/JB-5135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ