### PR TITLE
automatically restart juicebox and the snapshots service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - JB_DEFAULT_USERS_FILE
       - AWS_PROFILE
       - JB_SNAPSHOTS_SERVICE=http://snapshot:8080/snapshot/
+    restart: on-failure:10
   postgres:
     environment:
       - POSTGRES_USER=juicebox
@@ -84,3 +85,4 @@ services:
       - JB_DEBUG=true
     ports:
       - "8080:8080"
+    restart: on-failure:10

--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -862,14 +862,11 @@ def _run(args, env, service="juicebox"):
 
 @cli.command()
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-@click.option("--env", help="Which environment to run docker-compose for")
 @click.option("--ganesha", default=False, is_flag=True, help="Enable ganesha")
-def dc(args, env, ganesha):
+def dc(args, ganesha):
     """Run docker-compose in a particular environment"""
     cmd = list(args)
-    if env is None:
-        env = dockerutil.check_home()
-    os.chdir(os.path.join(DEVLANDIA_DIR, "environments", env))
+    os.chdir(DEVLANDIA_DIR)
     dockerutil.docker_compose(cmd, ganesha=ganesha)
 
 

--- a/jbcli/jbcli/tests/test_docker.py
+++ b/jbcli/jbcli/tests/test_docker.py
@@ -17,8 +17,7 @@ class TestDocker:
         assert check_mock.mock_calls == [
             call(['docker-compose',
                   '--project-directory', '.', '--project-name', 'devlandia',
-                  '-f', 'docker-compose.yml','up',
-                  '--abort-on-container-exit'], env=None)
+                  '-f', 'docker-compose.yml','up'], env=None)
         ]
 
     @patch('jbcli.utils.dockerutil.check_call')
@@ -57,7 +56,6 @@ class TestDocker:
                 '-f', 'docker-compose-coolio.yml',
                 '-f', 'docker-compose-2pac.yml',
                 'up',
-                '--abort-on-container-exit',
             ], env=None)
         ]
 

--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -87,7 +87,7 @@ def docker_compose(args, env=None, ganesha=False):
 def up(env=None, ganesha=False):
     """Starts and optionally creates a Docker environment based on
     docker-compose.yml"""
-    docker_compose(["up", "--abort-on-container-exit"], env=env, ganesha=ganesha)
+    docker_compose(["up"], env=env, ganesha=ganesha)
 
 
 def run_jb(cmd, env=None, service="juicebox"):

--- a/jbcli/requirements-dev.txt
+++ b/jbcli/requirements-dev.txt
@@ -10,3 +10,4 @@ sphinx-rtd-theme==1.1.1
 pytest~=4.6.0
 flake8==3.4.1
 pytest-cov==2.8.1
+jinja2==3.0.3


### PR DESCRIPTION
## Changes

- remove `--abort-on-container-exit` from our `docker-compose up` command
- add `restart` policies to both juicebox and the snapshot service ("on-failure:10" means only restart on failure, and retry up to 10 times)

unrelatedly: fix `jb dc`, it was broken ever since we got rid of the `environments` subdirectories