### PR TITLE
Fixes 'is_running' function to properly report on self-serve and custom.

### DIFF
--- a/jbcli/jbcli/utils/dockerutil.py
+++ b/jbcli/jbcli/utils/dockerutil.py
@@ -136,7 +136,7 @@ def halt(arch=None, custom=False):
 
 
 def is_running():
-    """Checks whether or not a Juicebox container is currently running.
+    """Checks whether a Juicebox container is currently running.
 
     :rtype: ``bool``
     """
@@ -146,10 +146,9 @@ def is_running():
     print(containers)
     for container in containers:
         print(f"Checking images: {container.name}")
-        if "juicebox_custom" in container.name:
-            custom = True
-        if "juicebox_selfserve" in container.name:
-            selfserve = True
+        custom = custom or "devlandia_juicebox_custom_1" == container.name
+        selfserve = custom or "devlandia_juicebox_1" == container.name
+
     return [custom, selfserve]
 
 


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- Adjust the `is_running` function to properly report on self-serve and custom

## Documentation

- This will be used later to help fix `jb kick` and possibly others.

## Checklist

- [ ] Add information to the release notes documentation
- [ ] Add new feature to the usage documentation
- [ ] Add tests
