### PR TITLE
Fix: Add new HSTM secrets to docker-compose files

### DIFF
--- a/docker-compose.arm.custom.yml
+++ b/docker-compose.arm.custom.yml
@@ -68,4 +68,6 @@ services:
       - JB_HSTM
       - JB_DEFAULT_USERS_FILE
       - AWS_PROFILE
+      - HSTM_EMAIL_SECRET
+      - HSTM_CLIENT_SECRET
     restart: on-failure:10

--- a/docker-compose.arm.yml
+++ b/docker-compose.arm.yml
@@ -68,4 +68,6 @@ services:
       - JB_HSTM
       - JB_DEFAULT_USERS_FILE
       - AWS_PROFILE
+      - HSTM_EMAIL_SECRET
+      - HSTM_CLIENT_SECRET
     restart: on-failure:10

--- a/docker-compose.custom.yml
+++ b/docker-compose.custom.yml
@@ -69,4 +69,6 @@ services:
       - JB_DEFAULT_USERS_FILE
       - AWS_PROFILE
       - JB_SNAPSHOTS_SERVICE=http://snapshot:8080/snapshot/
+      - HSTM_EMAIL_SECRET
+      - HSTM_CLIENT_SECRET
     restart: on-failure:10

--- a/docker-compose.selfserve.yml
+++ b/docker-compose.selfserve.yml
@@ -69,4 +69,6 @@ services:
       - JB_DEFAULT_USERS_FILE
       - AWS_PROFILE
       - JB_SNAPSHOTS_SERVICE=http://snapshot:8080/snapshot/
+      - HSTM_EMAIL_SECRET
+      - HSTM_CLIENT_SECRET
     restart: on-failure:10


### PR DESCRIPTION
Ticket: [JB-5376]
Type: Fix

#### This PR introduces the following changes

- After we added the new secrets in parameter store for Jim, they still weren't recognized, but it seems it's because we hadn't added the key names to the docker-compose environment variables.
- The key now gets populated in the settings correctly.
- I think this is only applicable for custom at the moment, but I added the variables to the selfserve compose files, too, just in case they ever get used, and so we don't have to go through troubleshooting again after we've forgotten about it.

[JB-5376]: https://juiceanalytics.atlassian.net/browse/JB-5376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ