### PR TITLE
Fix: update tag_replacement value for core-custom

### DIFF
--- a/jbcli/jbcli/cli/jb.py
+++ b/jbcli/jbcli/cli/jb.py
@@ -460,7 +460,7 @@ def start(
     # A dictionary of environment names and tags to use
     tag_replacements = OrderedDict()
     tag_replacements["core"] = "develop-py3"
-    tag_replacements["core-custom"] = "prod-custom"
+    tag_replacements["core-custom"] = "prod-custom-py3"
     tag_replacements["dev"] = "develop-py3"
     tag_replacements["stable"] = "master-py3"
     tag_replacements["hstm-dev"] = "hstm-qa"


### PR DESCRIPTION
Ticket: NA
Type: Fix

#### This PR introduces the following changes

- Up until now the single arm image has been fine, but since the big recipe refactor, the arm image is incompatible for older branches.  I made a new branch based on 3.95 to build the arm image and tagged it as prod-custom-py3.  We had a placeholder value for the core-custom environment, but it was set to prod-custom, which was an x86 image.  Updated the mapping for core-custom to point at prod-custom-py3 and Binh was able to get it working.  To start an older branch we'll do `jb start core-custom --custom` it seems a bit redundant, but the first is the environment, and the custom flag tells us how it should behave so they're still both needed.