### PR TITLE
Upgrade Sphinx so that Docs build again

### DIFF
--- a/jbcli/requirements-dev.txt
+++ b/jbcli/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 bumpversion==0.5.3
-Sphinx==3.4
+Sphinx~=7.2.6
 coverage==4.5.4
 mock==1.3.0
 pytest-runner==5.2
 requests-mock==1.7.0
 pip-tools==4.1.0
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==2.0.0
 pytest~=4.6.0
 flake8==6.0.0
 pytest-cov==2.8.1

--- a/jbcli/requirements-dev.txt
+++ b/jbcli/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 bumpversion==0.5.3
-Sphinx==1.6.1
+Sphinx==3.4
 coverage==4.5.4
 mock==1.3.0
 pytest-runner==5.2


### PR DESCRIPTION
Ticket: NA
Type: Fix

#### This PR introduces the following changes

- The last few merges show as failed because it couldn't build the docs due to the version of Sphinx.  Upgraded the package and tested locally and it worked as expected.