### PR TITLE
Upgrade Postgres Image from 12 to 15

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,3 +1,3 @@
-FROM postgres:12.14-alpine
+FROM postgres:15.5-alpine
 
 COPY create_db.sh /docker-entrypoint-initdb.d


### PR DESCRIPTION
Type: Improvement

#### This PR introduces the following changes

- Now that we've upgraded all of the deployed Postgres versions to 15, we want to upgrade the image used in Devlandia so there are no backward incompatible issues while developing.
- Upgraded the image referenced in Dockerfile.postgres
- Tested starting up Devlandia and everything seems normal
- Developers will need to stop and restart Devlandia to get the new image.